### PR TITLE
bump version of libtuf

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= {
   val slickV = "3.1.1"
   val sotaV = "0.2.89"
   val bouncyCastleV = "1.56"
-  val tufV = "0.0.1-42-g2f4cd4f"
+  val tufV = "0.0.1-54-gcfe584a"
 
   Seq(
     "com.typesafe.akka" %% "akka-actor" % akkaV,

--- a/src/test/scala/com/advancedtelematic/director/manifest/SignatureVerificationSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/manifest/SignatureVerificationSpec.scala
@@ -37,18 +37,14 @@ class SignatureVerificationSpec extends DirectorSpec {
     val keys = generate(size = 1024)
     val data = "0123456789abcdef".getBytes
 
-    // We change only one bit so lets just increment it like gray code
-    // https://en.wikipedia.org/wiki/Gray_code
-    val grayCodedChar = {
-      val seq = "01326754cdfeab980"
-      seq.zip(seq.tail).toMap
-    }
+    def updateBit(c: Char): Char = (c ^ 1).toChar
 
     val sig = {
       val orig = sign(keys.getPrivate, data)
-      val origHex = orig.hex.get
-      val newHex = (grayCodedChar(origHex.head) +: origHex.tail).refineTry[ValidSignature].get
-      orig.copy(hex = newHex)
+      val origSig = orig.sig.get
+
+      val newSig = (updateBit(origSig.head) +: origSig.tail).refineTry[ValidSignature].get
+      orig.copy(sig = newSig)
     }
     val clientKey = ClientKey(RSA, keys.getPublic)
 


### PR DESCRIPTION
`ValidSignature` no longer requires length to be `256` characters long, but it should be in Base64 rather than Hex.