### PR TITLE
setEcusAction was used twice (and incorrectly)

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/db/DeviceUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/DeviceUpdate.scala
@@ -87,14 +87,12 @@ object DeviceUpdate extends AdminRepositorySupport
 
   def clearTargets(namespace: Namespace, device: DeviceId, ecuImages: Seq[EcuManifest])
                   (implicit db: Database, ec: ExecutionContext): Future[Option[UpdateId]] = {
-    val dbAct = setEcusAction(namespace, device, ecuImages){
-      for {
+    val dbAct = for {
         _ <- setEcusAction(namespace, device, ecuImages)(DBIO.successful(None))
         next_version <- deviceRepository.getNextVersionAction(device)
         updateId <- adminRepository.fetchUpdateIdAction(namespace, device, next_version)
         _ <- clearTargetsFrom(namespace, device, next_version)
       } yield updateId
-    }
 
     db.run(dbAct.transactionally)
   }


### PR DESCRIPTION
Somehow the code for `clearTargets` called `setEcusAction` twice, it is very likely that the `setEcusAction` will not do anything since we are expecting the same report as before.
In either case we always want todo the rest so having it in the (conditional) continuation was wrong.