### PR TITLE
Add HardwareId for every ecu

### DIFF
--- a/src/main/resources/db/migration/V7__add_hardware_identifier.sql
+++ b/src/main/resources/db/migration/V7__add_hardware_identifier.sql
@@ -1,0 +1,9 @@
+ALTER TABLE `ecus`
+ADD `hardware_identifier` VARCHAR(64) NULL;
+
+UPDATE `ecus` e
+SET e.hardware_identifier = e.ecu_serial
+WHERE e.hardware_identifier IS NULL;
+
+ALTER TABLE `ecus`
+MODIFY `hardware_identifier` VARCHAR(64) NOT NULL;

--- a/src/main/scala/com/advancedtelematic/director/data/AdminRequest.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/AdminRequest.scala
@@ -5,7 +5,7 @@ import com.advancedtelematic.libtuf.data.ClientDataType.ClientKey
 object AdminRequest {
   import DataType._
 
-  final case class RegisterEcu(ecu_serial: EcuSerial, clientKey: ClientKey)
+  final case class RegisterEcu(ecu_serial: EcuSerial, hardware_identifier: HardwareIdentifier, clientKey: ClientKey)
 
   final case class RegisterDevice(vin: DeviceId, primary_ecu_serial: EcuSerial, ecus: Seq[RegisterEcu])
 

--- a/src/main/scala/com/advancedtelematic/director/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/DataType.scala
@@ -30,6 +30,10 @@ object DataType {
   type EcuSerial = Refined[String, ValidEcuSerial]
   implicit val validEcuSerial: Validate.Plain[String, ValidEcuSerial] = ValidationUtils.validInBetween(min = 1, max = 64, ValidEcuSerial())
 
+  final case class ValidHardwareIdentifier()
+  type HardwareIdentifier = Refined[String, ValidHardwareIdentifier]
+  implicit val validHardwareIdentifier: Validate.Plain[String, ValidHardwareIdentifier] = ValidationUtils.validInBetween(min = 0, max = 64, ValidHardwareIdentifier())
+
   final case class FileInfo(hashes: Hashes, length: Int)
   final case class Image(filepath: String, fileinfo: FileInfo)
 
@@ -38,7 +42,8 @@ object DataType {
   }
 
 
-  final case class Ecu(ecuSerial: EcuSerial, device: DeviceId, namespace: Namespace, primary: Boolean, clientKey: ClientKey)
+  final case class Ecu(ecuSerial: EcuSerial, device: DeviceId, namespace: Namespace, primary: Boolean,
+                       hardwareId: HardwareIdentifier, clientKey: ClientKey)
 
   final case class CurrentImage (ecuSerial: EcuSerial, image: Image, attacksDetected: String)
 

--- a/src/test/scala/com/advancedtelematic/director/data/CodecsSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/CodecsSpec.scala
@@ -78,15 +78,16 @@ class CodecsSpec extends DirectorSpec {
         |ZQIDAQAB
         |-----END PUBLIC KEY-----""".stripMargin + "\n"
 
+    val hardwareId = "hw-type"
     val clientKey = s"""{"keytype": "RSA", "keyval": {"public": "${pubKey.replace("\n","\\n")}"}}"""
-    val ecus = s"""{"ecu_serial": "$ecu_serial", "clientKey": $clientKey}"""
+    val ecus = s"""{"ecu_serial": "$ecu_serial", "hardware_identifier": "$hardwareId", "clientKey": $clientKey}"""
 
     val sample = s"""{"primary_ecu_serial": "$ecu_serial", "ecus": [$ecus]}"""
 
     val p_ecu_serial = ecu_serial.refineTry[ValidEcuSerial].get
     val p_pubKey = RsaKeyPair.parsePublic(pubKey).get
     val p_clientKey = ClientKey(KeyType.RSA, p_pubKey)
-    val parsed = DeviceRegistration(p_ecu_serial, Seq(RegisterEcu(p_ecu_serial, p_clientKey)))
+    val parsed = DeviceRegistration(p_ecu_serial, Seq(RegisterEcu(p_ecu_serial, hardwareId.refineTry[ValidHardwareIdentifier].get, p_clientKey)))
 
     example(sample, parsed)
   }

--- a/src/test/scala/com/advancedtelematic/director/data/GeneratorOps.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/GeneratorOps.scala
@@ -21,8 +21,9 @@ object GeneratorOps {
   }
 
   implicit class GenAtMost[T](gen: Gen[T]) {
-    final def atMost(n: Int): Gen[List[T]] = Gen.choose(0, n).flatMap(Gen.containerOfN[List, T](_, gen))
-    final def nonEmptyAtMost(n: Int): Gen[List[T]] = Gen.choose(1, n).flatMap(Gen.containerOfN[List, T](_, gen))
+    final def atMost(n: Int): Gen[List[T]] = listBetween(0, n)
+    final def nonEmptyAtMost(n: Int): Gen[List[T]] = listBetween(1, n)
+    final def listBetween(lower: Int, upper: Int): Gen[List[T]] = Gen.choose(lower, upper).flatMap(Gen.containerOfN[List, T](_, gen))
   }
 
   def GenStringByChar(gen: Gen[Char]) =

--- a/src/test/scala/com/advancedtelematic/director/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/Generators.scala
@@ -35,10 +35,14 @@ trait Generators {
     pubKey = RsaKeyPair.generate(size = 128).getPublic
   } yield ClientKey(keyType, pubKey)
 
+  lazy val GenHardwareIdentifier: Gen[HardwareIdentifier] =
+    Gen.choose(10,64).flatMap(GenRefinedStringByCharN(_, Gen.alphaChar))
+
   lazy val GenRegisterEcu: Gen[RegisterEcu] = for {
     ecu <- GenEcuSerial
+    hwId <- GenHardwareIdentifier
     crypto <- GenClientKey
-  } yield RegisterEcu(ecu, crypto)
+  } yield RegisterEcu(ecu, hwId, crypto)
 
   lazy val GenKeyId: Gen[KeyId]= GenRefinedStringByCharN(64, GenHexChar)
 

--- a/src/test/scala/com/advancedtelematic/director/http/DeviceResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/DeviceResourceSpec.scala
@@ -18,9 +18,9 @@ import io.circe.syntax._
 class DeviceResourceSpec extends DirectorSpec with DefaultPatience with ResourceSpec with Requests {
   test("Can register device") {
     val device = DeviceId.generate()
-    val primEcu = GenEcuSerial.generate
-    val primCrypto = GenClientKey.generate
-    val ecus =GenRegisterEcu.atMost(5).generate ++ (RegisterEcu(primEcu, primCrypto) :: GenRegisterEcu.atMost(5).generate)
+    val primEcuReg = GenRegisterEcu.generate
+    val primEcu = primEcuReg.ecu_serial
+    val ecus = GenRegisterEcu.atMost(5).generate ++ (primEcuReg :: GenRegisterEcu.atMost(5).generate)
 
     val regDev = RegisterDevice(device, primEcu, ecus)
 
@@ -39,9 +39,9 @@ class DeviceResourceSpec extends DirectorSpec with DefaultPatience with Resource
 
   test("Device can update a registered device") {
     val device = DeviceId.generate()
-    val primEcu = GenEcuSerial.generate
-    val primCrypto = GenClientKey.generate
-    val ecus = GenRegisterEcu.atMost(5).generate ++ (RegisterEcu(primEcu, primCrypto) :: GenRegisterEcu.atMost(5).generate)
+    val primEcuReg = GenRegisterEcu.generate
+    val primEcu = primEcuReg.ecu_serial
+    val ecus = GenRegisterEcu.atMost(5).generate ++ (primEcuReg :: GenRegisterEcu.atMost(5).generate)
 
     val regDev = RegisterDevice(device, primEcu, ecus)
 
@@ -56,11 +56,11 @@ class DeviceResourceSpec extends DirectorSpec with DefaultPatience with Resource
 
   test("Device must have the ecu given as primary") {
     val device = DeviceId.generate()
-    val primEcu = GenEcuSerial.generate
-    val primCrypto = GenClientKey.generate
+    val primEcuReg = GenRegisterEcu.generate
+    val primEcu = primEcuReg.ecu_serial
     val fakePrimEcu = GenEcuSerial.generate
     val ecus = GenRegisterEcu.atMost(5).generate ++
-      (RegisterEcu(primEcu, primCrypto) :: GenRegisterEcu.atMost(5).generate)
+      (primEcuReg :: GenRegisterEcu.atMost(5).generate)
 
     val regDev = RegisterDevice(device, primEcu, ecus)
 
@@ -75,14 +75,12 @@ class DeviceResourceSpec extends DirectorSpec with DefaultPatience with Resource
 
   test("Device need to have the correct primary") {
     val device = DeviceId.generate()
-    val primEcu = GenEcuSerial.generate
-    val primCrypto = GenClientKey.generate
-    val fakePrimEcu = GenEcuSerial.generate
-    val fakePrimCrypto = GenClientKey.generate
+    val primEcuReg = GenRegisterEcu.generate
+    val primEcu = primEcuReg.ecu_serial
+    val fakePrimEcuReg = GenRegisterEcu.generate
+    val fakePrimEcu = fakePrimEcuReg.ecu_serial
     val ecus = GenRegisterEcu.atMost(5).generate ++
-      (RegisterEcu(primEcu, primCrypto) ::
-       RegisterEcu(fakePrimEcu, fakePrimCrypto) ::
-       GenRegisterEcu.atMost(5).generate)
+      (primEcuReg :: fakePrimEcuReg :: GenRegisterEcu.atMost(5).generate)
 
     val regDev = RegisterDevice(device, primEcu, ecus)
 
@@ -108,13 +106,13 @@ class DeviceResourceSpec extends DirectorSpec with DefaultPatience with Resource
 
 
     val device = DeviceId.generate()
-    val primEcu = GenEcuSerial.generate
-    val primCrypto = GenClientKey.generate
-    val ecusWork = GenRegisterEcu.atMost(5).generate ++ (RegisterEcu(primEcu, primCrypto) :: GenRegisterEcu.atMost(5).generate)
+    val primEcuReg = GenRegisterEcu.generate
+    val primEcu = primEcuReg.ecu_serial
+    val ecusWork = GenRegisterEcu.atMost(5).generate ++ (primEcuReg :: GenRegisterEcu.atMost(5).generate)
     val ecusFail = GenEcuSerial.nonEmptyAtMost(5).generate.map{ecu =>
-      val clientKey = GenClientKey.generate
-      taintedKeys.put(clientKey.keyval, Unit)
-      RegisterEcu(ecu, clientKey)
+      val regEcu = GenRegisterEcu.generate
+      taintedKeys.put(regEcu.clientKey.keyval, Unit)
+      regEcu
     }
     val ecus = ecusWork ++ ecusFail
 
@@ -150,9 +148,9 @@ class DeviceResourceSpec extends DirectorSpec with DefaultPatience with Resource
 
   test("Can set target for device") {
     val device = DeviceId.generate()
-    val primEcu = GenEcuSerial.generate
-    val primCrypto = GenClientKey.generate
-    val ecus = List(RegisterEcu(primEcu, primCrypto))
+    val primEcuReg = GenRegisterEcu.generate
+    val primEcu = primEcuReg.ecu_serial
+    val ecus = List(primEcuReg)
 
     val regDev = RegisterDevice(device, primEcu, ecus)
 
@@ -165,9 +163,9 @@ class DeviceResourceSpec extends DirectorSpec with DefaultPatience with Resource
 
   test("Device can update to set target") {
     val device = DeviceId.generate()
-    val primEcu = GenEcuSerial.generate
-    val primCrypto = GenClientKey.generate
-    val ecus = List(RegisterEcu(primEcu, primCrypto))
+    val primEcuReg = GenRegisterEcu.generate
+    val primEcu = primEcuReg.ecu_serial
+    val ecus = List(primEcuReg)
 
     val regDev = RegisterDevice(device, primEcu, ecus)
 
@@ -193,9 +191,9 @@ class DeviceResourceSpec extends DirectorSpec with DefaultPatience with Resource
 
   test("Device can report current current") {
     val device = DeviceId.generate()
-    val primEcu = GenEcuSerial.generate
-    val primCrypto = GenClientKey.generate
-    val ecus = List(RegisterEcu(primEcu, primCrypto))
+    val primEcuReg = GenRegisterEcu.generate
+    val primEcu = primEcuReg.ecu_serial
+    val ecus = List(primEcuReg)
 
     val regDev = RegisterDevice(device, primEcu, ecus)
 
@@ -216,9 +214,9 @@ class DeviceResourceSpec extends DirectorSpec with DefaultPatience with Resource
 
   test("Successful campaign update is reported to core") {
     val device = DeviceId.generate()
-    val primEcu = GenEcuSerial.generate
-    val primCrypto = GenClientKey.generate
-    val ecus = List(RegisterEcu(primEcu, primCrypto))
+    val primEcuReg = GenRegisterEcu.generate
+    val primEcu = primEcuReg.ecu_serial
+    val ecus = List(primEcuReg)
 
     val regDev = RegisterDevice(device, primEcu, ecus)
 
@@ -251,9 +249,9 @@ class DeviceResourceSpec extends DirectorSpec with DefaultPatience with Resource
   test("Failed campaign update is reported to core and cancels remaing") {
 
     val device = DeviceId.generate()
-    val primEcu = GenEcuSerial.generate
-    val primCrypto = GenClientKey.generate
-    val ecus = List(RegisterEcu(primEcu, primCrypto))
+    val primEcuReg = GenRegisterEcu.generate
+    val primEcu = primEcuReg.ecu_serial
+    val ecus = List(primEcuReg)
 
     val regDev = RegisterDevice(device, primEcu, ecus)
 
@@ -286,9 +284,9 @@ class DeviceResourceSpec extends DirectorSpec with DefaultPatience with Resource
 
   test("Device update to target counts as failed campaign") {
     val device = DeviceId.generate()
-    val primEcu = GenEcuSerial.generate
-    val primCrypto = GenClientKey.generate
-    val ecus = List(RegisterEcu(primEcu, primCrypto))
+    val primEcuReg = GenRegisterEcu.generate
+    val primEcu = primEcuReg.ecu_serial
+    val ecus = List(primEcuReg)
 
     val regDev = RegisterDevice(device, primEcu, ecus)
 


### PR DESCRIPTION
Add a field `hardware_identifier` for each ecu in the provisioning,

notice that the provisioning script needs to change before we can test this properly.