### PR TITLE
backwards compat for hardwareId

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/data/AdminRequest.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/AdminRequest.scala
@@ -5,7 +5,16 @@ import com.advancedtelematic.libtuf.data.ClientDataType.{ClientKey, ClientHashes
 object AdminRequest {
   import DataType._
 
-  final case class RegisterEcu(ecu_serial: EcuSerial, hardware_identifier: HardwareIdentifier, clientKey: ClientKey)
+  final case class RegisterEcu(ecu_serial: EcuSerial, hardware_identifier: Option[HardwareIdentifier], clientKey: ClientKey) {
+    import eu.timepit.refined.api.Refined
+    // TODO: for backwards compatible reasons we allow the hardware_identifier to not be present in the request
+    // and use the ecu_serial as the hardware_identifer
+    lazy val hardwareId: HardwareIdentifier = hardware_identifier.getOrElse(Refined.unsafeApply(ecu_serial.get))
+  }
+  object RegisterEcu {
+    def apply (ecu_serial: EcuSerial, hardware_identifier: HardwareIdentifier, clientKey: ClientKey): RegisterEcu =
+      RegisterEcu(ecu_serial, Some(hardware_identifier), clientKey)
+  }
 
   final case class RegisterDevice(vin: DeviceId, primary_ecu_serial: EcuSerial, ecus: Seq[RegisterEcu])
 

--- a/src/main/scala/com/advancedtelematic/director/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/Codecs.scala
@@ -55,7 +55,12 @@ object Codecs {
 
   /*** Admin Request ***/
   implicit val decoderRegisterEcu: Decoder[RegisterEcu] = deriveDecoder
-  implicit val encoderRegisterEcu: Encoder[RegisterEcu] = deriveEncoder
+  implicit val encoderRegisterEcu: Encoder[RegisterEcu] = deriveEncoder[RegisterEcu].mapJsonObject{ obj =>
+    JsonObject.fromMap(obj.toMap.filter{
+                         case ("hardware_identifier", value) => !value.isNull
+                         case _ => true
+                       })
+  }
 
   implicit val decoderRegisterDevice: Decoder[RegisterDevice] = deriveDecoder
   implicit val encoderRegisterDevice: Encoder[RegisterDevice] = deriveEncoder

--- a/src/main/scala/com/advancedtelematic/director/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Repository.scala
@@ -108,7 +108,7 @@ protected class AdminRepository()(implicit db: Database, ec: ExecutionContext) {
     val clean = Schema.currentImage.filter(_.id in toClean.map(_.ecuSerial)).delete.andThen(toClean.delete)
 
     def register(reg: RegisterEcu) =
-      Schema.ecu += Ecu(reg.ecu_serial, device, namespace, reg.ecu_serial == primEcu, reg.hardware_identifier, reg.clientKey)
+      Schema.ecu += Ecu(reg.ecu_serial, device, namespace, reg.ecu_serial == primEcu, reg.hardwareId, reg.clientKey)
 
     val act = clean.andThen(DBIO.sequence(ecus.map(register)))
 
@@ -222,7 +222,7 @@ protected class DeviceRepository()(implicit db: Database, ec: ExecutionContext) 
 
   def create(namespace: Namespace, device: DeviceId, primEcu: EcuSerial, ecus: Seq[RegisterEcu]): Future[Unit] = {
     def register(reg: RegisterEcu) =
-      Schema.ecu += Ecu(reg.ecu_serial, device, namespace, reg.ecu_serial == primEcu, reg.hardware_identifier, reg.clientKey)
+      Schema.ecu += Ecu(reg.ecu_serial, device, namespace, reg.ecu_serial == primEcu, reg.hardwareId, reg.clientKey)
 
     val dbAct = byDevice(namespace, device).exists.result.flatMap {
       case false => DBIO.sequence(ecus.map(register)).map(_ => ())

--- a/src/test/scala/com/advancedtelematic/director/data/CodecsSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/CodecsSpec.scala
@@ -27,7 +27,7 @@ class CodecsSpec extends DirectorSpec {
       decode[T](sample) shouldBe Right(parsed)
     }
 
-    test(s"$name encodes corrcetly}") {
+    test(s"$name encodes correctly}") {
       parse(sample) shouldBe Right(parsed.asJson)
     }
   }
@@ -90,6 +90,31 @@ class CodecsSpec extends DirectorSpec {
     val parsed = DeviceRegistration(p_ecu_serial, Seq(RegisterEcu(p_ecu_serial, hardwareId.refineTry[ValidHardwareIdentifier].get, p_clientKey)))
 
     example(sample, parsed)
+  }
+
+  {
+    import com.advancedtelematic.libtuf.crypt.RsaKeyPair
+    val ecu_serial = "ecu1111"
+    val pubKey =
+      """-----BEGIN PUBLIC KEY-----
+        |MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1cUg8reXsHhoU4QefD+s
+        |1cUCmwlenPuIdg9gS4dWMXtIn0X/22zT7rMSQbE5mJxI7lVT8FZivqqwwNdC2Ami
+        |PhICu8GKuXMeK8yvvQaI5y5fcwwWFbt+7UI5d8r7g6p1toqDcSHv/Xe+F7Tcw/UA
+        |RaqjkaETMYSHo/ksJGHNIsjnG495ShBVt/nm12CUwtB7VQKrKYs2/JgJPOo8rzTj
+        |U23kk0SlNEHP8tRfUdY7hmtETFvvkM0T2mLRFVBg3487/iKFG503GgtKGI7Njsxz
+        |df1h5aFqNMXUbr4y+GNZXGBjXzY+udx57O12ujvp9gYd0Uacn1aT2u2dSt13I8V4
+        |ZQIDAQAB
+        |-----END PUBLIC KEY-----""".stripMargin + "\n"
+
+    val clientKey = s"""{"keytype": "RSA", "keyval": {"public": "${pubKey.replace("\n","\\n")}"}}"""
+    val sample = s"""{"ecu_serial": "$ecu_serial", "clientKey": $clientKey}"""
+
+    val p_ecu_serial = ecu_serial.refineTry[ValidEcuSerial].get
+    val p_pubKey = RsaKeyPair.parsePublic(pubKey).get
+    val p_clientKey = ClientKey(KeyType.RSA, p_pubKey)
+    val parsed = RegisterEcu(p_ecu_serial, None, p_clientKey)
+
+    example(sample, parsed, "without hardware_identifier")
   }
 
   {

--- a/src/test/scala/com/advancedtelematic/director/http/SetMultiTargetSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/SetMultiTargetSpec.scala
@@ -29,7 +29,7 @@ class SetMultiTargetSpec extends DirectorSpec
 
     registerDeviceOk(regDev)
 
-    val mtu = GenMultiTargetUpdateRequest.generate.copy(hardwareId = primEcuReg.hardware_identifier)
+    val mtu = GenMultiTargetUpdateRequest.generate.copy(hardwareId = primEcuReg.hardwareId)
 
     createMultiTargetUpdateOK(mtu)
 
@@ -56,7 +56,7 @@ class SetMultiTargetSpec extends DirectorSpec
 
     val updateId = UpdateId.generate
     val mtus = ecusThatWillUpdate.map { regEcu =>
-      GenMultiTargetUpdateRequest.generate.copy(hardwareId = regEcu.hardware_identifier,
+      GenMultiTargetUpdateRequest.generate.copy(hardwareId = regEcu.hardwareId,
                                                 id = updateId)
     }
 
@@ -90,7 +90,7 @@ class SetMultiTargetSpec extends DirectorSpec
     val devManifest = GenSignedDeviceManifest(primEcu, ecuManifest).generate
     updateManifestOk(device, devManifest)
 
-    val mtu = GenMultiTargetUpdateRequest.generate.copy(hardwareId = primEcuReg.hardware_identifier)
+    val mtu = GenMultiTargetUpdateRequest.generate.copy(hardwareId = primEcuReg.hardwareId)
 
     createMultiTargetUpdateOK(mtu)
 


### PR DESCRIPTION
In order to be backwards compatible with the old provisioning script that doesn't provide a hardware_identifier we make the field optional.
If the field is not set we use the `ecu_serial` similar to how the db-migration did for old devices.