### PR TITLE
permute the check on manifest

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/manifest/AfterUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/AfterUpdate.scala
@@ -16,6 +16,8 @@ import slick.driver.MySQLDriver.api._
 
 sealed abstract class DeviceManifestUpdateResult
 
+final case class NoChange() extends DeviceManifestUpdateResult
+
 final case class SuccessWithoutUpdateId() extends DeviceManifestUpdateResult
 
 final case class SuccessWithUpdateId(namespace: Namespace, device: DeviceId, updateId: UpdateId,
@@ -34,6 +36,7 @@ class AfterDeviceManifestUpdate(coreClient: CoreClient)
     with UpdateTypesRepositorySupport {
 
   val report: DeviceManifestUpdateResult => Future[Unit] = {
+    case NoChange() => FastFuture.successful(Unit)
     case SuccessWithoutUpdateId() => FastFuture.successful(Unit)
     case res:SuccessWithUpdateId =>
       updateTypesRepository.getType(res.updateId).flatMap {


### PR DESCRIPTION
Previously we checked if the manifest received was the same as the old
one first, and if not we checked if the new manifest is what we want.

This had the unfortunate consequence of not allowing updates to the same
target the device is already at (and forever blocking updates). So these
checks were permuted.

I tried to clean up the code as well, this code is still a bit tricky
though.