### PR TITLE
[PRO-2982] map install version to ecu

### DIFF
--- a/src/main/resources/db/migration/V11__add_optional_from_mtu.sql
+++ b/src/main/resources/db/migration/V11__add_optional_from_mtu.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `multi_target_updates`
+ADD COLUMN `from_target` CHAR(200) NULL,
+ADD COLUMN `from_target_hash` CHAR(128) NULL,
+ADD COLUMN `from_hash_method` CHAR(20) NULL,
+ADD COLUMN `from_target_size` LONG NULL
+;

--- a/src/main/scala/com/advancedtelematic/director/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/Codecs.scala
@@ -71,6 +71,9 @@ object Codecs {
   implicit val decoderTargetUpdate: Decoder[TargetUpdate] = deriveDecoder
   implicit val encoderTargetUpdate: Encoder[TargetUpdate] = deriveEncoder
 
+  implicit val decoderTargetUpdateRequest: Decoder[TargetUpdateRequest] = deriveDecoder
+  implicit val encoderTargetUpdateRequest: Encoder[TargetUpdateRequest] = deriveEncoder
+
   implicit val multiTargetUpdateCreatedEncoder: Encoder[MultiTargetUpdateRequest] = deriveEncoder
   implicit val multiTargetUpdateCreatedDecoder: Decoder[MultiTargetUpdateRequest] = deriveDecoder
 

--- a/src/main/scala/com/advancedtelematic/director/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/DataType.scala
@@ -78,7 +78,8 @@ object DataType {
 
   final case class RootFile(namespace: Namespace, rootFile: Json)
 
-  final case class MultiTargetUpdate(id: UpdateId, hardwareId: HardwareIdentifier, target: TargetFilename, checksum: Checksum,
+  final case class MultiTargetUpdate(id: UpdateId, hardwareId: HardwareIdentifier, fromTarget: Option[TargetUpdate],
+                                     target: TargetFilename, checksum: Checksum,
                                      targetLength: Long, namespace: Namespace) {
     lazy val image: Image = {
       val clientHash = Map(checksum.method -> checksum.hash)
@@ -88,10 +89,10 @@ object DataType {
 
   object MultiTargetUpdate {
     def apply(mtu: MultiTargetUpdateRequest, id: UpdateId, namespace: Namespace): Seq[MultiTargetUpdate] =
-      mtu.targets.toSeq.map {case (hardwareId, target) =>
-        MultiTargetUpdate(id = id, hardwareId = hardwareId, target = target.target,
-                          checksum = target.checksum, targetLength = target.targetLength,
-                          namespace = namespace)
+      mtu.targets.toSeq.map {case (hardwareId, TargetUpdateRequest(from, target)) =>
+        MultiTargetUpdate(id = id, hardwareId = hardwareId, fromTarget = from,
+                          target = target.target, checksum = target.checksum,
+                          targetLength = target.targetLength, namespace = namespace)
       }
   }
 
@@ -102,7 +103,9 @@ object DataType {
     }
   }
 
-  final case class MultiTargetUpdateRequest(targets: Map[HardwareIdentifier, TargetUpdate])
+  final case class TargetUpdateRequest(from: Option[TargetUpdate], to: TargetUpdate)
+
+  final case class MultiTargetUpdateRequest(targets: Map[HardwareIdentifier, TargetUpdateRequest])
 
   final case class LaunchedMultiTargetUpdate(device: DeviceId, update: UpdateId, timestampVersion: Int,
                                              status: LaunchedMultiTargetUpdateStatus.Status)

--- a/src/main/scala/com/advancedtelematic/director/db/SetMultiTargets.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/SetMultiTargets.scala
@@ -1,7 +1,8 @@
 package com.advancedtelematic.director.db
 
 import akka.http.scaladsl.model.Uri
-import com.advancedtelematic.director.data.DataType.{CustomImage, DeviceId, LaunchedMultiTargetUpdate, UpdateId}
+import com.advancedtelematic.director.data.DataType.{CustomImage, DeviceId, EcuSerial, LaunchedMultiTargetUpdate,
+  MultiTargetUpdate, UpdateId}
 import com.advancedtelematic.director.data.LaunchedMultiTargetUpdateStatus
 import com.advancedtelematic.director.data.UpdateType
 import com.advancedtelematic.libats.data.Namespace
@@ -14,24 +15,69 @@ object SetMultiTargets extends AdminRepositorySupport
     with LaunchedMultiTargetUpdateRepositorySupport
     with UpdateTypesRepositorySupport {
 
-  //this composition should probably be somewhere else
-  implicit class MapOps[A,B](map: Map[A, B]) {
-    def composeMap[C](map2: Map[B, C]): Map[A, C] =
-      map.mapValues(map2.get(_)).collect { case (k, Some(v)) => k -> v}
+  protected [db] def resolve(namespace: Namespace, device: DeviceId, hwRows: Seq[MultiTargetUpdate])// updateId: UpdateId)
+                            (implicit db: Database, ec: ExecutionContext): DBIO[Map[EcuSerial, CustomImage]] = {
+    val hwTargets = hwRows.map(mtu => mtu.hardwareId -> ((mtu.fromTarget, CustomImage(mtu.image, Uri())))).toMap
+    for {
+      ecus <- adminRepository.fetchHwMappingAction(namespace, device)
+    } yield ecus.mapValues { case (hw, oimage) =>
+        hwTargets.get(hw).map{case (from, to) => (oimage, from, to)}.collect {
+          case (_, None, t) => t
+          case (Some(img), Some(tu), t) if img == tu.image => t
+        }
+    }.collect{ case (k, Some(v)) => k -> v}
   }
 
-  def setMultiUpdateTargets(namespace: Namespace, device: DeviceId, updateId: UpdateId)
-                           (implicit db: Database, ec: ExecutionContext): Future[Unit] = {
-    val dbAct = for {
-      hwRows <- multiTargetUpdatesRepository.fetchAction(updateId, namespace)
-      hwTargets = hwRows.map(mtu => mtu.hardwareId -> CustomImage(mtu.image, Uri())).toMap
+  protected [db] def checkMany(namespace: Namespace, devices: Seq[DeviceId], hwRows: Seq[MultiTargetUpdate])
+                              (implicit db: Database, ec: ExecutionContext): DBIO[Seq[DeviceId]] = {
+    def act(device: DeviceId): DBIO[Option[DeviceId]] = for {
       ecus <- adminRepository.fetchHwMappingAction(namespace, device)
-      targets = ecus.composeMap(hwTargets)
+      okay = hwRows.forall{ mtu =>
+        ecus.exists {case (_, (hw, current)) =>
+          hw == mtu.hardwareId && mtu.fromTarget.forall{ from =>
+            current.exists{ cur => cur == from.image}
+          }
+        }
+      }
+    } yield if (okay) Some(device) else None
+
+    for {
+      devs <- adminRepository.devicesNotInACampaign(devices).result
+      affected <- DBIO.sequence(devs.map(act)).map(_.collect{case Some(v) => v})
+    } yield affected
+  }
+
+  def findAffected(namespace: Namespace, devices: Seq[DeviceId], updateId: UpdateId)
+                  (implicit db: Database, ec: ExecutionContext): Future[Seq[DeviceId]] = db.run {
+    multiTargetUpdatesRepository.fetchAction(updateId, namespace).flatMap { hwRows =>
+      checkMany(namespace, devices, hwRows)
+    }
+  }
+
+  protected [db] def launchDeviceUpdate(namespace: Namespace, device: DeviceId, hwRows: Seq[MultiTargetUpdate], updateId: UpdateId)
+                                       (implicit db: Database, ec: ExecutionContext): DBIO[DeviceId] = {
+    val dbAct = for {
+      targets <- resolve(namespace, device, hwRows)
       new_version <- SetTargets.deviceAction(namespace, device, Some(updateId), targets)
       _ <- launchedMultiTargetUpdateRepository.persistAction(LaunchedMultiTargetUpdate(device, updateId, new_version, LaunchedMultiTargetUpdateStatus.Pending))
       _ <- updateTypesRepository.persistAction(updateId, UpdateType.MULTI_TARGET_UPDATE)
-    } yield ()
+    } yield device
 
-    db.run(dbAct.transactionally)
+    dbAct.transactionally
+  }
+
+  def setMultiUpdateTargets(namespace: Namespace, device: DeviceId, updateId: UpdateId)
+                           (implicit db: Database, ec: ExecutionContext): Future[Unit] =
+    setMultiUpdateTargetsForDevices(namespace, Seq(device), updateId).map(_ => Unit)
+
+  def setMultiUpdateTargetsForDevices(namespace: Namespace, devices: Seq[DeviceId], updateId: UpdateId)
+                                     (implicit db: Database, ec: ExecutionContext): Future[Seq[DeviceId]] = db.run {
+    val dbAct = for {
+      hwRows <- multiTargetUpdatesRepository.fetchAction(updateId, namespace)
+      toUpdate <- checkMany(namespace, devices, hwRows)
+      _ <- DBIO.sequence(toUpdate.map{ device => launchDeviceUpdate(namespace, device, hwRows, updateId)})
+    } yield toUpdate
+
+    dbAct.transactionally
   }
 }

--- a/src/test/scala/com/advancedtelematic/director/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/Generators.scala
@@ -108,7 +108,11 @@ trait Generators {
     checksum <- GenChecksum
   } yield TargetUpdate(target, checksum, size)
 
+  val GenTargetUpdateRequest: Gen[TargetUpdateRequest] = for {
+    targetUpdate <- GenTargetUpdate
+  } yield TargetUpdateRequest(None, targetUpdate)
+
   val GenMultiTargetUpdateRequest: Gen[MultiTargetUpdateRequest] = for {
-    targets <- Gen.mapOf(Gen.zip(GenHardwareIdentifier, GenTargetUpdate))
+    targets <- Gen.mapOf(Gen.zip(GenHardwareIdentifier, GenTargetUpdateRequest))
   } yield MultiTargetUpdateRequest(targets)
 }

--- a/src/test/scala/com/advancedtelematic/director/http/AdminResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/AdminResourceSpec.scala
@@ -1,7 +1,6 @@
 package com.advancedtelematic.director.http
 
-import akka.http.scaladsl.model.{HttpRequest, StatusCodes, Uri}
-import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{StatusCodes, Uri}
 import cats.syntax.show._
 import com.advancedtelematic.director.data.AdminRequest._
 import com.advancedtelematic.director.data.Codecs.encoderEcuManifest
@@ -9,6 +8,7 @@ import com.advancedtelematic.director.data.DataType._
 import com.advancedtelematic.director.data.GeneratorOps._
 import com.advancedtelematic.director.db.SetVersion
 import com.advancedtelematic.director.util.{DirectorSpec, ResourceSpec}
+import com.advancedtelematic.director.util.NamespaceTag._
 import com.advancedtelematic.libats.data.PaginationResult
 import com.advancedtelematic.libtuf.data.ClientDataType.{ClientKey, TargetFilename}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
@@ -17,18 +17,6 @@ import io.circe.Json
 import io.circe.syntax._
 
 class AdminResourceSpec extends DirectorSpec with ResourceSpec with Requests with SetVersion {
-  trait NamespaceTag {
-    val value: String
-  }
-
-  def withNamespace[T](ns: String)(fn: NamespaceTag => T): T =
-    fn(new NamespaceTag { val value = ns })
-
-  implicit class Namespaced(value: HttpRequest) {
-    def namespaced(implicit namespaceTag: NamespaceTag): HttpRequest =
-      value.addHeader(RawHeader("x-ats-namespace", namespaceTag.value))
-  }
-
   def registerDeviceOk(ecus: Int)(implicit ns: NamespaceTag): (DeviceId, EcuSerial, Seq[EcuSerial]) = {
     val device = DeviceId.generate
 

--- a/src/test/scala/com/advancedtelematic/director/http/LaunchMultiTargetUpdate.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/LaunchMultiTargetUpdate.scala
@@ -1,0 +1,139 @@
+package com.advancedtelematic.director.http
+
+import akka.http.scaladsl.model.StatusCodes
+import cats.syntax.show._
+import com.advancedtelematic.director.data.AdminRequest._
+import com.advancedtelematic.director.data.Codecs._
+import com.advancedtelematic.director.data.DataType._
+import com.advancedtelematic.director.data.GeneratorOps._
+import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, ResourceSpec}
+import com.advancedtelematic.director.util.NamespaceTag._
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import eu.timepit.refined.api.Refined
+
+class LaunchMultiTargetUpdate extends DirectorSpec with DefaultPatience with ResourceSpec with Requests {
+
+  val ato: TargetUpdate = GenTargetUpdate.generate.copy(target = Refined.unsafeApply("a"))
+  val bto: TargetUpdate = GenTargetUpdate.generate.copy(target = Refined.unsafeApply("b"))
+  val cto: TargetUpdate = GenTargetUpdate.generate.copy(target = Refined.unsafeApply("c"))
+  val dto: TargetUpdate = GenTargetUpdate.generate.copy(target = Refined.unsafeApply("d"))
+  val ahw: HardwareIdentifier = Refined.unsafeApply("a")
+  val bhw: HardwareIdentifier = Refined.unsafeApply("b")
+  val chw: HardwareIdentifier = Refined.unsafeApply("c")
+  val dhw: HardwareIdentifier = Refined.unsafeApply("d")
+
+  def registerNSDeviceOk(hwimages: (HardwareIdentifier, TargetUpdate)*)(implicit ns: NamespaceTag): DeviceId = {
+    val device = DeviceId.generate
+
+    val regEcus = hwimages.map { case (hw, _) =>
+      GenRegisterEcu.generate.copy(hardware_identifier = Some(hw))
+    }
+
+    val primEcu = regEcus.head.ecu_serial
+
+    registerDevice(RegisterDevice(device, primEcu, regEcus)).namespaced ~> routes ~> check {
+      status shouldBe StatusCodes.Created
+    }
+
+    val ecuManifest = hwimages.zip(regEcus.map(_.ecu_serial)).map {case ((hw, target), ecu) =>
+      val sig = GenSignedEcuManifest(ecu).generate
+      sig.copy(signed = sig.signed.copy(installed_image = target.image))
+    }
+
+    updateManifest(device, GenSignedDeviceManifest(primEcu, ecuManifest).generate).namespaced ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+    }
+
+    device
+  }
+
+  def createMtu(hwimages: (HardwareIdentifier, TargetUpdate)*)(implicit ns: NamespaceTag): UpdateId = {
+    val mtu = MultiTargetUpdateRequest(hwimages.toMap.mapValues(target => TargetUpdateRequest(None, target)))
+    Post(apiUri(s"multi_target_updates"), mtu).namespaced ~> routes ~> check {
+      status shouldBe StatusCodes.Created
+      responseAs[UpdateId]
+    }
+  }
+
+  def createMtuWithFrom(hwimages: (HardwareIdentifier, (TargetUpdate, TargetUpdate))*)(implicit ns: NamespaceTag): UpdateId = {
+    val mtu = MultiTargetUpdateRequest(hwimages.toMap.mapValues{ case (from,target) => TargetUpdateRequest(Some(from), target)})
+    Post(apiUri(s"multi_target_updates"), mtu).namespaced ~> routes ~> check {
+      status shouldBe StatusCodes.Created
+      responseAs[UpdateId]
+    }
+  }
+
+  def findAffected(updateId: UpdateId, devices: Seq[DeviceId])(implicit ns: NamespaceTag): Seq[DeviceId] =
+    Get(apiUri(s"admin/multi_target_updates/${updateId.show}/affected"), devices).namespaced ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Seq[DeviceId]]
+    }
+
+  def launchMtu(updateId: UpdateId, devices: Seq[DeviceId])(implicit ns: NamespaceTag): Seq[DeviceId] =
+    Put(apiUri(s"admin/multi_target_updates/${updateId.show}"), devices).namespaced ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Seq[DeviceId]]
+    }
+
+  test("multi_target_updates/affected Can get devices that match mtu") {
+    withRandomNamespace {implicit ns =>
+      val device1 = registerNSDeviceOk(ahw -> ato, bhw -> bto)
+      val device2 = registerNSDeviceOk(ahw -> ato, chw -> cto)
+      val device3 = registerNSDeviceOk(dhw -> dto)
+
+      val update = createMtu(ahw -> ato)
+      val affected = findAffected(update, Seq(device1, device2, device3))
+
+      affected.toSet.size shouldBe affected.size
+      affected.toSet shouldBe Set(device1, device2)
+    }
+  }
+
+  test("multi_target_updates/affected mtu with multiple updates") {
+    withRandomNamespace {implicit ns =>
+      val device1 = registerNSDeviceOk(ahw -> ato, bhw -> bto)
+      val device2 = registerNSDeviceOk(ahw -> ato, chw -> cto)
+      val device3 = registerNSDeviceOk(dhw -> dto)
+
+      val update = createMtu(ahw -> ato, bhw -> bto)
+      val affected = findAffected(update, Seq(device1, device2, device3))
+
+      affected.toSet.size shouldBe affected.size
+      affected.toSet shouldBe Set(device1)
+    }
+  }
+
+  test("multi_target_updates/affected mtu with from field") {
+    withRandomNamespace {implicit ns =>
+      val device1 = registerNSDeviceOk(ahw -> ato, bhw -> bto)
+      val device2 = registerNSDeviceOk(ahw -> bto, chw -> cto)
+      val device3 = registerNSDeviceOk(dhw -> dto)
+
+      val update = createMtuWithFrom(ahw -> (ato -> dto))
+      val affected = findAffected(update, Seq(device1, device2, device3))
+
+      affected.toSet.size shouldBe affected.size
+      affected.toSet shouldBe Set(device1)
+    }
+  }
+
+  test("multi_target_updates/affected mtu ignores devices in a campaign") {
+    withRandomNamespace {implicit ns =>
+      val device1 = registerNSDeviceOk(ahw -> ato, bhw -> bto)
+      val device2 = registerNSDeviceOk(ahw -> ato, chw -> cto)
+      val device3 = registerNSDeviceOk(dhw -> dto)
+
+      val update = createMtu(ahw -> ato)
+
+      val launched = launchMtu(update, Seq(device1))
+      launched shouldBe Seq(device1)
+
+      val launched2 = launchMtu(update, Seq(device1))
+      launched2 shouldBe Seq()
+
+      val affected = findAffected(update, Seq(device1, device2, device3))
+
+      affected shouldBe Seq(device2)
+    }
+  }
+}

--- a/src/test/scala/com/advancedtelematic/director/http/MultiTargetUpdatesResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/MultiTargetUpdatesResourceSpec.scala
@@ -2,13 +2,11 @@ package com.advancedtelematic.director.http
 
 import akka.http.scaladsl.model.StatusCodes
 import com.advancedtelematic.director.data.DataType.UpdateId
-import com.advancedtelematic.director.db.MultiTargetUpdatesRepositorySupport
+import com.advancedtelematic.director.data.GeneratorOps._
 import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, ResourceSpec}
 
-class MultiTargetUpdatesResourceSpec extends DirectorSpec with DefaultPatience with ResourceSpec with Requests
-  with MultiTargetUpdatesRepositorySupport {
+class MultiTargetUpdatesResourceSpec extends DirectorSpec with DefaultPatience with ResourceSpec with Requests {
 
-  import com.advancedtelematic.director.data.GeneratorOps._
 
   test("fetching non-existent target info returns 404") {
     val id = UpdateId.generate()
@@ -21,6 +19,6 @@ class MultiTargetUpdatesResourceSpec extends DirectorSpec with DefaultPatience w
     val mtu = GenMultiTargetUpdateRequest.generate
     val id = createMultiTargetUpdateOK(mtu)
 
-    fetchMultiTargetUpdate(id) shouldBe mtu.targets.mapValues(_.image)
+    fetchMultiTargetUpdate(id) shouldBe mtu.targets.mapValues(_.to.image)
   }
 }

--- a/src/test/scala/com/advancedtelematic/director/http/Requests.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/Requests.scala
@@ -7,13 +7,13 @@ import com.advancedtelematic.director.data.AdminRequest.{RegisterDevice, SetTarg
 import com.advancedtelematic.director.data.Codecs._
 import com.advancedtelematic.director.data.DataType.{DeviceId, EcuSerial, HardwareIdentifier, Image, MultiTargetUpdateRequest, UpdateId}
 import com.advancedtelematic.director.data.DeviceRequest.DeviceManifest
-import com.advancedtelematic.director.util.{DirectorSpec, ResourceSpec}
+import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, ResourceSpec}
 import com.advancedtelematic.libats.codecs.AkkaCirce._
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.SignedPayload
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 
-trait Requests extends DirectorSpec with ResourceSpec {
+trait Requests extends DirectorSpec with DefaultPatience with ResourceSpec {
   def registerDevice(regDev: RegisterDevice): HttpRequest = Post(apiUri("admin/devices"), regDev)
 
   def registerDeviceOk(regDev: RegisterDevice): Unit =

--- a/src/test/scala/com/advancedtelematic/director/util/DefaultPatience.scala
+++ b/src/test/scala/com/advancedtelematic/director/util/DefaultPatience.scala
@@ -5,7 +5,7 @@ import org.scalatest.concurrent.PatienceConfiguration
 import org.scalatest.time.{Millis, Seconds, Span}
 
 trait DefaultPatience extends PatienceConfiguration {
-  override implicit def patienceConfig = PatienceConfig(timeout = Span(10, Seconds), interval = Span(500, Millis))
+  override implicit def patienceConfig = PatienceConfig().copy(timeout = Span(10, Seconds), interval = Span(500, Millis))
 
   implicit val defaultTimeout = RouteTestTimeout(Span(5, Seconds))
 }

--- a/src/test/scala/com/advancedtelematic/director/util/NamespaceTag.scala
+++ b/src/test/scala/com/advancedtelematic/director/util/NamespaceTag.scala
@@ -1,0 +1,25 @@
+package com.advancedtelematic.director.util
+
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.headers.RawHeader
+import com.advancedtelematic.director.data.GeneratorOps._
+import org.scalacheck.Gen
+
+object NamespaceTag {
+  trait NamespaceTag {
+    val value: String
+  }
+
+  def withNamespace[T](ns: String)(fn: NamespaceTag => T): T =
+    fn(new NamespaceTag { val value = ns })
+
+  def withRandomNamespace[T](fn: NamespaceTag => T): T =
+    fn(new NamespaceTag {
+         val value = Gen.alphaChar.listBetween(100,150).generate.mkString
+       })
+
+  implicit class Namespaced(value: HttpRequest) {
+    def namespaced(implicit namespaceTag: NamespaceTag): HttpRequest =
+      value.addHeader(RawHeader("x-ats-namespace", namespaceTag.value))
+  }
+}


### PR DESCRIPTION
Add an optional from field in the multi_target_update, and also add endpoint to schedule several devices at the same time. This new endpoint will first check if the device is compatible  with the multi target update, this means that each row in in the mtu is covered, (checking that the hardwareId is correct, and that the from target is satisfied). Only devices that are compatible will be scheduled,

There is also an end-point to check which devices would be affected (i.e. is compatible), but doesn't schedule anything.