### PR TITLE
[PRO-3013] generate an empty target file for new devices

### DIFF
--- a/src/test/scala/com/advancedtelematic/director/db/SetVersion.scala
+++ b/src/test/scala/com/advancedtelematic/director/db/SetVersion.scala
@@ -1,7 +1,7 @@
 package com.advancedtelematic.director.db
 
 import akka.Done
-import com.advancedtelematic.director.data.DataType.{DeviceId, DeviceUpdateTarget}
+import com.advancedtelematic.director.data.DataType.{DeviceId, DeviceCurrentTarget, DeviceUpdateTarget}
 import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.MySQLProfile.api._
 
@@ -9,6 +9,12 @@ trait SetVersion {
   def setCampaign(device: DeviceId, version: Int)
                  (implicit db: Database, ec: ExecutionContext): Future[Done] = db.run {
     (Schema.deviceTargets += DeviceUpdateTarget(device, None, version))
+      .map(_ => Done)
+  }
+
+  def setDeviceVersion(device: DeviceId, version: Int)
+                      (implicit db: Database, ec: ExecutionContext): Future[Done] = db.run {
+    (Schema.deviceCurrentTarget.insertOrUpdate(DeviceCurrentTarget(device, version)))
       .map(_ => Done)
   }
 }

--- a/src/test/scala/com/advancedtelematic/director/http/AdminResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/AdminResourceSpec.scala
@@ -152,7 +152,6 @@ class AdminResourceSpec extends DirectorSpec with ResourceSpec with Requests wit
       val device1 = registerNSDeviceOk(afn, bfn)
       val device2 = registerNSDeviceOk(afn)
 
-      setCampaign(device1, 0).futureValue
       setCampaign(device1, 1).futureValue
 
       val pag = getAffected("a")()
@@ -166,7 +165,8 @@ class AdminResourceSpec extends DirectorSpec with ResourceSpec with Requests wit
       val device1 = registerNSDeviceOk(afn, bfn)
       val device2 = registerNSDeviceOk(afn)
 
-      setCampaign(device1, 0).futureValue
+      setCampaign(device1, 1).futureValue
+      setDeviceVersion(device1, 1).futureValue
 
       val pag = getAffected("a")()
       pag.total shouldBe 2
@@ -195,8 +195,6 @@ class AdminResourceSpec extends DirectorSpec with ResourceSpec with Requests wit
   }
 
   test("devices/id gives a list of ecuresponses") {
-
-
     withNamespace("check ecuresponse") {implicit ns =>
       val images = Seq(afn, bfn)
       val (device, primEcu, ecusSerials) = createDeviceWithImages(images : _*)


### PR DESCRIPTION
When a device is registered, we create an empty targets file (and snapshot, and timestamp) that will be version `0`.