### PR TITLE
Fix a concurrency bug where multiple updates

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/db/DeviceUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/DeviceUpdate.scala
@@ -70,7 +70,7 @@ object DeviceUpdate extends AdminRepositorySupport
   private [db] def clearTargetsFromAction(namespace: Namespace, device: DeviceId, version: Int)
                                            (implicit db: Database, ec: ExecutionContext): DBIO[Int] = {
     val dbAct = for {
-      latestVersion <- adminRepository.getLatestVersion(namespace, device)
+      latestVersion <- adminRepository.getLatestScheduledVersion(namespace, device)
       nextTimestampVersion = latestVersion + 1
       fcr = FileCacheRequest(namespace, version, device, None, FileCacheRequestStatus.PENDING, nextTimestampVersion)
       _ <- deviceRepository.updateDeviceVersionAction(device, nextTimestampVersion)

--- a/src/main/scala/com/advancedtelematic/director/db/SetTargets.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/SetTargets.scala
@@ -16,7 +16,7 @@ object SetTargets extends AdminRepositorySupport
     with UpdateTypesRepositorySupport {
 
   protected [db] def deviceAction(namespace: Namespace, device: DeviceId, updateId: Option[UpdateId], targets: Map[EcuSerial, CustomImage])
-                          (implicit db: Database, ec: ExecutionContext): DBIO[Int] =
+                                 (implicit db: Database, ec: ExecutionContext): DBIO[Int] =
     adminRepository.updateTargetAction(namespace, device, updateId, targets).flatMap { new_version =>
       val fcr = FileCacheRequest(namespace, new_version, device, updateId, FileCacheRequestStatus.PENDING, new_version)
       fileCacheRequestRepository.persistAction(fcr).map(_ => new_version)

--- a/src/test/scala/com/advancedtelematic/director/db/SetVersion.scala
+++ b/src/test/scala/com/advancedtelematic/director/db/SetVersion.scala
@@ -1,15 +1,18 @@
 package com.advancedtelematic.director.db
 
 import akka.Done
-import com.advancedtelematic.director.data.DataType.{DeviceCurrentTarget, DeviceUpdateTarget}
+import com.advancedtelematic.director.data.DataType.{DeviceCurrentTarget, FileCacheRequest}
+import com.advancedtelematic.director.data.FileCacheRequestStatus
+import com.advancedtelematic.director.util.NamespaceTag.NamespaceTag
+import com.advancedtelematic.libats.data.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.MySQLProfile.api._
 
 trait SetVersion {
   def setCampaign(device: DeviceId, version: Int)
-                 (implicit db: Database, ec: ExecutionContext): Future[Done] = db.run {
-    (Schema.deviceTargets += DeviceUpdateTarget(device, None, version))
+                 (implicit db: Database, ec: ExecutionContext, ns: NamespaceTag): Future[Done] = db.run {
+    (Schema.fileCacheRequest += FileCacheRequest(Namespace(ns.value), version, device, None, FileCacheRequestStatus.PENDING, version))
       .map(_ => Done)
   }
 

--- a/src/test/scala/com/advancedtelematic/director/http/AdminResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/AdminResourceSpec.scala
@@ -156,6 +156,7 @@ class AdminResourceSpec extends DirectorSpec with FileCacheDB with ResourceSpec 
       val device2 = registerNSDeviceOk(afn)
 
       setCampaign(device1, 1).futureValue
+      pretendToGenerate.futureValue
 
       val pag = getAffected("a")()
       pag.total shouldBe 1


### PR DESCRIPTION
Where if you schedule multiple updaets for one device in quick
succession then they would get the same timestamp version and conflict.

Thanks @simao