### PR TITLE
Add a migration to create repos

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/migration/CreateUsersBoot.scala
+++ b/src/main/scala/com/advancedtelematic/director/migration/CreateUsersBoot.scala
@@ -1,16 +1,19 @@
 package com.advancedtelematic.director.migration
 
 import akka.Done
+import akka.http.scaladsl.util.FastFuture
 import com.advancedtelematic.director.{Settings, VersionInfo}
-import com.advancedtelematic.director.daemon.CreateRepoActor
 import com.advancedtelematic.director.db.RepoNameRepositorySupport
 import com.advancedtelematic.director.db.Errors.MissingNamespaceRepo
+import com.advancedtelematic.director.http.RootFileDownloadActor
 import com.advancedtelematic.libats.data.Namespace
 import com.advancedtelematic.libats.http.BootApp
-import com.advancedtelematic.libats.messaging_datatype.Messages.UserCreated
 import com.advancedtelematic.libats.slick.db.{BootMigrations, DatabaseConfig}
+import com.advancedtelematic.libtuf.data.TufDataType.RepoId
 import com.advancedtelematic.libtuf.keyserver.KeyserverHttpClient
 import scala.concurrent.Future
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 object CreateUsersBoot extends BootApp
     with Settings
@@ -23,11 +26,21 @@ object CreateUsersBoot extends BootApp
 
   log.info("Starting migration for CreateUsers")
 
-  require(args.length == 1, "need to pass a filepath to read namespaces from")
-  val fp = args.head
+  val (dryRun: Boolean, fileOfNamespaces: String) = args match {
+    case Array("--dryrun", fp) => (true, fp)
+    case Array(fp) if fp != "--dryrun" => (false, fp)
+    case _ =>
+      log.error("wrong arguments passed should be of the form: [--dryrun] filename")
+      sys.exit(1)
+  }
 
-  val tuf = new KeyserverHttpClient(tufUri)
-  val createRepoListener = system.actorOf(CreateRepoActor.props(tuf), "create-repo-listener")
+  def readNamespaces(fp: String): Seq[Namespace] = {
+    scala.io.Source.fromFile(fp).mkString.lines.toSeq.map(Namespace)
+  }
+
+  val namespaces = readNamespaces(fileOfNamespaces)
+
+  val keyserverClient = new KeyserverHttpClient(tufUri)
 
   def checkIfExists(ns: Namespace): Future[Boolean] =
     repoNameRepository.getRepo(ns).map(_ => true).recover {
@@ -35,29 +48,33 @@ object CreateUsersBoot extends BootApp
     }
 
   def migrate(ns: Namespace): Future[Done] = {
-    checkIfExists(ns).map {
+    checkIfExists(ns).flatMap {
       case true =>
         log.info(s"Namespace ${ns.get} already exists, skipping")
-        Done
+        FastFuture.successful(Done)
       case false =>
         log.info(s"Creating repo for ${ns.get}")
-        createRepoListener ! UserCreated(ns.get)
-        Done
+        if (dryRun) {
+          log.info(s"[DRYRUN] createRepoListener ! UserCreated(${ns.get})")
+          FastFuture.successful(Done)
+        } else {
+          val repoId = RepoId.generate
+          keyserverClient.createRoot(repoId).map{_ =>
+            system.actorOf(RootFileDownloadActor.props(ns, keyserverClient, repoId))
+            Done
+          }
+        }
     }
   }
 
   def migrateAll(namespaces: Seq[Namespace]): Future[Done] = {
-    // this might be stupid, maybe should buffer them somehow
-    Future.traverse(namespaces)(migrate).map(_ => Done)
+    val bufferSize = 5
+
+    namespaces.grouped(bufferSize).toSeq.foldLeft(Future.successful(Done)) {
+      (acc, group) => acc.flatMap(_ => Future.traverse(group)(migrate).map(_ => Done))
+    }
   }
 
-  def readNamespaces(fp: String): Seq[Namespace] = {
-    scala.io.Source.fromFile(fp).mkString.lines.toSeq.map(Namespace)
-  }
-
-  val namespaces = readNamespaces(fp)
-
-  migrateAll(namespaces).foreach { case Done =>
-    log.info(s"Migration finished")
-  }
+  Await.result(migrateAll(namespaces), Duration.Inf)
+  log.info(s"Migration finished")
 }


### PR DESCRIPTION
This adds a new application that will read a file (provided as an
argument to th application) of namespaces that will be added (only if
they don't already exists).

example:
> sbt "run-main com.advancedtelematic.director.migration.CreateUsersBoot
/path/to/file"

This will need access to the keyserver, and the database.