### PR TITLE
[PRO-3454] publish UpdateSpec event

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/data/Messages.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/Messages.scala
@@ -1,0 +1,70 @@
+package com.advancedtelematic.director.data
+
+import com.advancedtelematic.director.data.MessageDataType.UpdateStatus.UpdateStatus
+import com.advancedtelematic.director.data.MessageDataType.SOTA_Instant
+import com.advancedtelematic.director.data.Messages.UpdateSpec
+import com.advancedtelematic.libats.codecs.Codecs._
+import com.advancedtelematic.libats.codecs.CirceEnum
+import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.messaging.Messages.MessageLike
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
+import java.time.Instant
+import java.util.UUID
+
+object MessageDataType {
+
+  object UpdateStatus extends CirceEnum {
+    type UpdateStatus = Value
+
+    val Pending, InFlight, Canceled, Failed, Finished = Value
+  }
+
+  final case class SOTA_Instant(inner: Instant) extends AnyVal
+
+  object SOTA_Instant {
+    def now(): SOTA_Instant = SOTA_Instant(Instant.now())
+  }
+}
+
+object MessageCodecs {
+  import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+  import io.circe.generic.semiauto._
+  import java.time.format.{DateTimeFormatter, DateTimeParseException}
+
+  implicit val dateTimeEncoder : Encoder[SOTA_Instant] =
+    Encoder.instance[SOTA_Instant]( x =>  Json.fromString( x.inner.toString) )
+
+  implicit val dateTimeDecoder : Decoder[SOTA_Instant] = Decoder.instance { c =>
+    c.focus.flatMap(_.asString) match {
+      case None       => Left(DecodingFailure("DataTime", c.history))
+      case Some(date) =>
+        try {
+          val fmt = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+          val nst = SOTA_Instant(Instant.from(fmt.parse(date)))
+          Right(nst)
+        }
+        catch {
+          case t: DateTimeParseException =>
+            Left(DecodingFailure("DateTime", c.history))
+        }
+    }
+  }
+
+  implicit val updateSpecEncoder: Encoder[UpdateSpec] = deriveEncoder
+  implicit val updateSpecDecoder: Decoder[UpdateSpec] = deriveDecoder
+}
+
+object Messages {
+  import MessageCodecs._
+
+  final case class UpdateSpec(namespace: Namespace, device: DeviceId, packageUuid: UpdateId, status: UpdateStatus, timestamp: SOTA_Instant = SOTA_Instant.now())
+
+  object UpdateSpec {
+    def apply(namespace: Namespace, device: DeviceId, status: UpdateStatus): UpdateSpec = {
+      val pkgUuid = UpdateId(UUID.fromString("00000000-0000-0000-0000-000000000000"))
+      UpdateSpec(namespace, device, pkgUuid, status)
+    }
+  }
+
+  implicit val updateSpecLike = MessageLike[UpdateSpec](_.device.toString)
+}

--- a/src/test/scala/com/advancedtelematic/director/data/CodecsSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/CodecsSpec.scala
@@ -5,8 +5,9 @@ import com.advancedtelematic.director.data.Codecs._
 import com.advancedtelematic.director.data.DataType.{FileInfo, Image, ValidHardwareIdentifier}
 import com.advancedtelematic.director.data.DeviceRequest.{CustomManifest, DeviceRegistration, EcuManifest, OperationResult}
 import com.advancedtelematic.director.util.DirectorSpec
+import com.advancedtelematic.libats.data.Namespace
 import com.advancedtelematic.libats.data.RefinedUtils._
-import com.advancedtelematic.libats.messaging_datatype.DataType.{HashMethod, ValidChecksum, ValidEcuSerial}
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, HashMethod, UpdateId, ValidChecksum, ValidEcuSerial}
 import com.advancedtelematic.libtuf.data.ClientDataType.ClientKey
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.{ClientSignature, KeyType, SignatureMethod, SignedPayload, ValidKeyId, ValidSignature}
@@ -14,6 +15,7 @@ import io.circe.{Decoder, Encoder}
 import io.circe.parser._
 import io.circe.syntax._
 import java.time.Instant
+import java.util.UUID
 
 import eu.timepit.refined.api.Refined
 
@@ -151,5 +153,32 @@ class CodecsSpec extends DirectorSpec {
     )
 
     example(sample, parsed, "with custom field")
+  }
+
+  {
+    import com.advancedtelematic.director.data.Messages.UpdateSpec
+    import com.advancedtelematic.director.data.MessageCodecs._
+    import com.advancedtelematic.director.data.MessageDataType.{SOTA_Instant, UpdateStatus}
+    import java.time.format.DateTimeFormatter
+
+    val sample: String = """{"namespace":"the updateSpec namespace","device":"61d89c4f-b238-4fff-ad7a-b2f0a196230a","packageUuid":"32eb10cc-7431-4945-9b4b-145abb26f69e","status":"Finished","timestamp":"2017-07-03T12:35:32.353Z"}"""
+
+    val parsed: UpdateSpec = UpdateSpec(Namespace("the updateSpec namespace"),
+                                        DeviceId(UUID.fromString("61d89c4f-b238-4fff-ad7a-b2f0a196230a")),
+                                        UpdateId(UUID.fromString("32eb10cc-7431-4945-9b4b-145abb26f69e")),
+                                        UpdateStatus.Finished,
+                                        SOTA_Instant(Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse("2017-07-03T12:35:32.353Z"))))
+
+    example(sample, parsed, "UpdateSpec event")
+  }
+
+  {
+    import com.advancedtelematic.director.data.Messages.UpdateSpec
+    import com.advancedtelematic.director.data.MessageDataType.UpdateStatus
+
+    val sample: String = "\"00000000-0000-0000-0000-000000000000\""
+    val parsed: UpdateId = UpdateSpec(Namespace("the updateSpec namespace"), DeviceId.generate, UpdateStatus.Failed).packageUuid
+
+    example(sample, parsed, "UpdateSpec creates zero uuid for packageUuid")
   }
 }

--- a/src/test/scala/com/advancedtelematic/director/http/SetMultiTargetSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/SetMultiTargetSpec.scala
@@ -17,6 +17,8 @@ class SetMultiTargetSpec extends DirectorSpec
     with ResourceSpec
     with Requests {
 
+  val setMultiTargets = new SetMultiTargets()
+
   test("can schedule a multi-target update") {
     val device = DeviceId.generate
     val primEcuReg = GenRegisterEcu.generate
@@ -31,7 +33,7 @@ class SetMultiTargetSpec extends DirectorSpec
 
     val mtuId = createMultiTargetUpdateOK(mtu)
 
-    SetMultiTargets.setMultiUpdateTargets(defaultNs, device, mtuId).futureValue
+    setMultiTargets.setMultiUpdateTargets(defaultNs, device, mtuId).futureValue
     val update = adminRepository.fetchTargetVersion(defaultNs, device, 1).futureValue
 
     update shouldBe Map(primEcu -> CustomImage(targetUpdate.to.image, Uri()))
@@ -60,7 +62,7 @@ class SetMultiTargetSpec extends DirectorSpec
     }.toMap
 
     val f = async {
-      await(SetMultiTargets.setMultiUpdateTargets(defaultNs, device, updateId))
+      await(setMultiTargets.setMultiUpdateTargets(defaultNs, device, updateId))
       val update = await(adminRepository.fetchTargetVersion(defaultNs, device, 1))
       update shouldBe expected
     }
@@ -87,7 +89,7 @@ class SetMultiTargetSpec extends DirectorSpec
     val mtuId = createMultiTargetUpdateOK(mtu)
 
     async {
-      await(SetMultiTargets.setMultiUpdateTargets(defaultNs, device, mtuId))
+      await(setMultiTargets.setMultiUpdateTargets(defaultNs, device, mtuId))
       val update = await(adminRepository.fetchTargetVersion(defaultNs, device, 1))
       update shouldBe Map(primEcu -> CustomImage(targetUpdate.to.image, Uri()))
     }.futureValue


### PR DESCRIPTION
In order to update the status of the device in the device registry
we need to publish an `UpdateSpec` event for the multi target update
updates. Normally this is done by core, but for multi target updates
core is not involved so we(the director) need to do it.

Notice that the UpdateSpec event contains a field that is called
`packageUuid` which doesn't make any sense for the multi target update,
this field is not used neither by the device registry nor the ui. So I'm
filling it with the updateId from the multi target update, which of
course feels wrong, but it will work for now. The `UpdateSpec`
event will probably be removed in the future, so abusing the
`packageUuid` field is probably okay...

Also notice that the codecs for `Instant` is different between rvi-sota
and libats, so I created a SOTA_Instant type that will use the old
codecs.