### PR TITLE
[PRO-3361] change format for device manifest

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/data/DeviceRequest.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/DeviceRequest.scala
@@ -1,7 +1,6 @@
 package com.advancedtelematic.director.data
 
 import com.advancedtelematic.libats.messaging_datatype.DataType.EcuSerial
-import com.advancedtelematic.libtuf.data.TufDataType.SignedPayload
 import io.circe.Json
 
 import java.time.Instant
@@ -17,7 +16,7 @@ object DeviceRequest {
                                custom: Option[Json] = None)
 
   final case class DeviceManifest(primary_ecu_serial: EcuSerial,
-                                  ecu_version_manifest: Seq[SignedPayload[EcuManifest]])
+                                  ecu_version_manifests: Map[EcuSerial, Json])
 
   final case class DeviceRegistration(primary_ecu_serial: EcuSerial,
                                       ecus: Seq[AdminRequest.RegisterEcu])

--- a/src/main/scala/com/advancedtelematic/director/manifest/DeviceManifestUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/DeviceManifestUpdate.scala
@@ -23,16 +23,19 @@ class DeviceManifestUpdate(afterUpdate: AfterDeviceManifestUpdate,
     with UpdateTypesRepositorySupport {
   private lazy val _log = LoggerFactory.getLogger(this.getClass)
 
-  def setDeviceManifest(namespace: Namespace, device: DeviceId, signedDevMan: SignedPayload[DeviceManifest]): Future[Unit] = async {
-    val ecus = await(deviceRepository.findEcus(namespace, device))
-    val ecuImages = await(Future.fromTry(Verify.deviceManifest(ecus, verifier, signedDevMan)))
+  def setDeviceManifest(namespace: Namespace, device: DeviceId, signedDevMan: SignedPayload[DeviceManifest]): Future[Unit] = for {
+    ecus <- deviceRepository.findEcus(namespace, device)
+    ecuImages <- Future.fromTry(Verify.deviceManifest(ecus, verifier, signedDevMan))
+    _ <- ecuManifests(namespace, device, ecuImages)
+  } yield ()
 
+  def ecuManifests(namespace: Namespace, device: DeviceId, ecuImages: Seq[EcuManifest]): Future[Unit] = async {
     val updateResult = {
-      val operations = deviceManifestOperationResults(signedDevMan.signed)
+      val operations = deviceManifestOperationResults(ecuImages)
       if (operations.isEmpty) {
         await(clientReportedNoErrors(namespace, device, ecuImages, None))
       } else if (operations.forall(_._2.isSuccess)) {
-          await(clientReportedNoErrors(namespace, device, ecuImages, Some(operations)))
+        await(clientReportedNoErrors(namespace, device, ecuImages, Some(operations)))
       } else {
         _log.info(s"Device ${device.show} reports errors during install: $operations")
         val currentVersion = await(deviceRepository.getCurrentVersion(device))
@@ -40,6 +43,7 @@ class DeviceManifestUpdate(afterUpdate: AfterDeviceManifestUpdate,
       }
     }
     await(afterUpdate.report(updateResult))
+
   }
 
   private def clientReportedNoErrors(namespace: Namespace, device: DeviceId, ecuImages: Seq[EcuManifest],
@@ -60,8 +64,8 @@ class DeviceManifestUpdate(afterUpdate: AfterDeviceManifestUpdate,
         Failed(namespace, device, currentVersion, None)
     }
 
-  private def deviceManifestOperationResults(deviceManifest: DeviceManifest): Map[EcuSerial, OperationResult] =
-    deviceManifest.ecu_version_manifest.par.map(_.signed).flatMap{ ecuManifest =>
+  private def deviceManifestOperationResults(ecuManifests: Seq[EcuManifest]): Map[EcuSerial, OperationResult] =
+    ecuManifests.par.flatMap{ ecuManifest =>
       ecuManifest.custom.flatMap(_.as[CustomManifest].toOption).map{ custom =>
         val op = custom.operation_result
         val image = ecuManifest.installed_image

--- a/src/main/scala/com/advancedtelematic/director/manifest/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/Errors.scala
@@ -7,6 +7,7 @@ import com.advancedtelematic.libats.http.ErrorCode
 
 object ErrorCodes {
   val EcuNotPrimary = ErrorCode("ecu_not_primary")
+  val WrongEcuSerialInEcuManifest = ErrorCode("wrong_ecu_serial_not_in_ecu_manifest")
   val EmptySignatureList = ErrorCode("empty_signature_list")
   val SignatureMethodMismatch = ErrorCode("signature_method_mismatch")
   val SignatureNotValid = ErrorCode("signature_not_valid")
@@ -18,4 +19,5 @@ object Errors {
   val EmptySignatureList = RawError(ErrorCodes.EmptySignatureList, StatusCodes.BadRequest, "The given signature list is empty")
   val SignatureMethodMismatch = RawError(ErrorCodes.SignatureMethodMismatch, StatusCodes.BadRequest, "The given signature method and the stored signature method are different")
   val SignatureNotValid = RawError(ErrorCodes.SignatureNotValid, StatusCodes.BadRequest, "The given signature is not valid")
+  val WrongEcuSerialInEcuManifest = RawError(ErrorCodes.WrongEcuSerialInEcuManifest, StatusCodes.BadRequest, "The ecu serial in ecu-manifest dosen't matched the one in device-manifest")
 }

--- a/src/main/scala/com/advancedtelematic/director/manifest/Verify.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/Verify.scala
@@ -1,11 +1,14 @@
 package com.advancedtelematic.director.manifest
 
+import cats.syntax.either._
 import com.advancedtelematic.director.data.DataType.Ecu
 import com.advancedtelematic.director.data.DeviceRequest.{DeviceManifest, EcuManifest}
 import com.advancedtelematic.director.data.Codecs._
+import com.advancedtelematic.libats.messaging_datatype.DataType.EcuSerial
 import com.advancedtelematic.libtuf.crypt.CanonicalJson._
 import com.advancedtelematic.libtuf.crypt.Sha256Digest
 import com.advancedtelematic.libtuf.data.ClientDataType.ClientKey
+import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.{ClientSignature, Signature, SignedPayload}
 import io.circe.Encoder
 import io.circe.syntax._
@@ -57,20 +60,29 @@ object Verify {
     }
 
   def deviceManifest(ecusForDevice: Seq[Ecu],
-                     verifier: ClientKey => Verifier,
-                     signedDevMan: SignedPayload[DeviceManifest]): Try[Seq[EcuManifest]] = {
-    val ecuMap = ecusForDevice.groupBy(_.ecuSerial).mapValues(_.head)
-    for {
-      primaryEcu <- ecuMap.get(signedDevMan.signed.primary_ecu_serial)
-                          .fold[Try[Ecu]](Failure(Errors.EcuNotFound))(Success(_))
-      _ <- tryCondition(primaryEcu.primary, Errors.EcuNotPrimary)
-      devMan <- checkSigned(signedDevMan, verifier(primaryEcu.clientKey))
-      verifiedEcu = devMan.ecu_version_manifest.map { sEcu =>
-        ecuMap.get(sEcu.signed.ecu_serial) match {
-          case None => Failure(Errors.EcuNotFound)
-          case Some(ecu) => checkSigned(sEcu, verifier(ecu.clientKey))
-        }
+                        verifier: ClientKey => Verifier,
+                        signedDevMan: SignedPayload[DeviceManifest]): Try[Seq[EcuManifest]] = {
+    val ecuMap = ecusForDevice.map(x => x.ecuSerial -> x).toMap
+
+    def findEcu(ecuSerial: EcuSerial)(handler: PartialFunction[Ecu, Throwable] = PartialFunction.empty): Try[Ecu] =
+      ecuMap.get(ecuSerial) match {
+        case None => Failure(Errors.EcuNotFound)
+        case Some(ecu) => if (handler.isDefinedAt(ecu)) Failure(handler(ecu)) else Success(ecu)
       }
-    } yield verifiedEcu.collect { case Success(x) => x}
+
+    for {
+      primaryEcu <- findEcu(signedDevMan.signed.primary_ecu_serial){
+        case ecu if !ecu.primary => Errors.EcuNotPrimary
+      }
+      devMan <- checkSigned(signedDevMan, verifier(primaryEcu.clientKey))
+      verifiedEcus = devMan.ecu_version_manifests.map { case (ecuSerial, jsonBlob) =>
+        for {
+          ecu <- findEcu(ecuSerial)()
+          sEcumanifest <- jsonBlob.as[SignedPayload[EcuManifest]].toTry
+          () <- Either.cond(sEcumanifest.signed.ecu_serial == ecuSerial, (), Errors.WrongEcuSerialInEcuManifest).toTry
+          ecuManifest <- checkSigned(sEcumanifest, verifier(ecu.clientKey))
+        } yield ecuManifest
+      }.toSeq
+    } yield verifiedEcus.collect { case Success(x) => x }
   }
 }

--- a/src/test/scala/com/advancedtelematic/director/data/CodecsSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/CodecsSpec.scala
@@ -3,11 +3,11 @@ package com.advancedtelematic.director.data
 import com.advancedtelematic.director.data.AdminRequest.RegisterEcu
 import com.advancedtelematic.director.data.Codecs._
 import com.advancedtelematic.director.data.DataType.{FileInfo, Image, ValidHardwareIdentifier}
-import com.advancedtelematic.director.data.DeviceRequest.{CustomManifest, DeviceRegistration, EcuManifest, OperationResult}
+import com.advancedtelematic.director.data.DeviceRequest.{CustomManifest, DeviceManifest, DeviceRegistration, EcuManifest, OperationResult}
 import com.advancedtelematic.director.util.DirectorSpec
 import com.advancedtelematic.libats.data.Namespace
 import com.advancedtelematic.libats.data.RefinedUtils._
-import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, HashMethod, UpdateId, ValidChecksum, ValidEcuSerial}
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, HashMethod, UpdateId, ValidChecksum, ValidEcuSerial}
 import com.advancedtelematic.libtuf.data.ClientDataType.ClientKey
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.{ClientSignature, KeyType, SignatureMethod, SignedPayload, ValidKeyId, ValidSignature}
@@ -22,7 +22,7 @@ import eu.timepit.refined.api.Refined
 import scala.reflect.ClassTag
 
 class CodecsSpec extends DirectorSpec {
-  def example[T : Decoder : Encoder](sample: String, parsed: T, msg: String = "")(implicit ct: ClassTag[T]): Unit = {
+  def exampleDecode[T : Decoder](sample: String, parsed: T, msg: String = "")(implicit ct: ClassTag[T]): Unit = {
     val name = if (msg == "") {
       ct.runtimeClass.getSimpleName
     } else {
@@ -32,10 +32,23 @@ class CodecsSpec extends DirectorSpec {
     test(s"$name decodes correctly") {
       decode[T](sample) shouldBe Right(parsed)
     }
+  }
+
+  def exampleEncode[T : Encoder](sample: String, parsed: T, msg: String = "")(implicit ct: ClassTag[T]): Unit = {
+    val name = if (msg == "") {
+      ct.runtimeClass.getSimpleName
+    } else {
+      ct.runtimeClass.getSimpleName + s" ($msg)"
+    }
 
     test(s"$name encodes correctly}") {
       parse(sample) shouldBe Right(parsed.asJson)
     }
+  }
+
+  def example[T : ClassTag : Decoder : Encoder](sample: String, parsed: T, msg: String = ""): Unit = {
+    exampleDecode(sample, parsed, msg)
+    exampleEncode(sample, parsed, msg)
   }
 
   {
@@ -180,5 +193,45 @@ class CodecsSpec extends DirectorSpec {
     val parsed: UpdateId = UpdateSpec(Namespace("the updateSpec namespace"), DeviceId.generate, UpdateStatus.Failed).packageUuid
 
     example(sample, parsed, "UpdateSpec creates zero uuid for packageUuid")
+  }
+  {
+    def wrapSample(inner: String): String = s"""{"signatures": [{"method": "rsassa-pss", "sig": "df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804", "keyid": "49309f114b857e4b29bfbff1c1c75df59f154fbc45539b2eb30c8a867843b2cb"}], "signed": $inner}"""
+
+    val ecu_manifest_sample: String = wrapSample("""{"timeserver_time": "2016-10-14T16:06:03Z", "installed_image": {"filepath": "/file2.txt", "fileinfo": {"hashes": {"sha256": "3910b632b105b1e03baa9780fc719db106f2040ebfe473c66710c7addbb2605a"}, "length": 21}}, "previous_timeserver_time": "2016-10-14T16:06:03Z", "ecu_serial": "ecu11111", "attacks_detected": ""}""")
+
+    def wrapSigned[T : Encoder](t: T): SignedPayload[T] =
+      SignedPayload(signatures = Vector(ClientSignature(
+                              method = SignatureMethod.RSASSA_PSS,
+                              sig = "df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804".refineTry[ValidSignature].get,
+                              keyid = "49309f114b857e4b29bfbff1c1c75df59f154fbc45539b2eb30c8a867843b2cb".refineTry[ValidKeyId].get)),
+
+        signed = t)
+
+    val ecuSerial: EcuSerial = "ecu11111".refineTry[ValidEcuSerial].get
+    val ecu_manifest_sample_parsed: SignedPayload[EcuManifest]
+      = wrapSigned(EcuManifest(timeserver_time = Instant.ofEpochSecond(1476461163),
+                               installed_image = Image(
+                                 filepath = Refined.unsafeApply("/file2.txt"),
+                                 fileinfo = FileInfo(
+                                   hashes = Map(HashMethod.SHA256 -> "3910b632b105b1e03baa9780fc719db106f2040ebfe473c66710c7addbb2605a".refineTry[ValidChecksum].get),
+                                   length = 21)),
+                               previous_timeserver_time = Instant.ofEpochSecond(1476461163),
+                               ecu_serial = ecuSerial,
+                               attacks_detected = ""))
+
+    // notice that legacy spelled it `ecu_version_manifest` rather than `ecu_version_manifests`, and did not use a Map
+    // but only had a sequence of signed ecu_manifests
+    val legacy_device_manifest_sample: String = wrapSample(s"""{"primary_ecu_serial": "ecu11111", "ecu_version_manifest": [$ecu_manifest_sample]}""")
+    val device_manifest_sample: String = wrapSample(s"""{"primary_ecu_serial": "ecu11111", "ecu_version_manifests": {"ecu11111": $ecu_manifest_sample}}""")
+
+    val device_manifest_parsed: SignedPayload[DeviceManifest]
+      = wrapSigned(DeviceManifest(ecuSerial, Map(ecuSerial -> ecu_manifest_sample_parsed.asJson)))
+
+
+    // we only need to decode the device manifest, hence we only test that
+    // since we don't have a legacy encoder
+    exampleDecode(legacy_device_manifest_sample, device_manifest_parsed, "legacy")
+
+    example(device_manifest_sample, device_manifest_parsed, "normal")
   }
 }

--- a/src/test/scala/com/advancedtelematic/director/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/Generators.scala
@@ -8,8 +8,9 @@ import com.advancedtelematic.director.data.DeviceRequest._
 import com.advancedtelematic.director.data.GeneratorOps._
 import com.advancedtelematic.libats.messaging_datatype.DataType.{EcuSerial, HashMethod, ValidChecksum, ValidTargetFilename}
 import com.advancedtelematic.libtuf.crypt.RsaKeyPair
-import com.advancedtelematic.libtuf.data.TufDataType._
 import com.advancedtelematic.libtuf.data.ClientDataType.{ClientHashes, ClientKey}
+import com.advancedtelematic.libtuf.data.TufCodecs._
+import com.advancedtelematic.libtuf.data.TufDataType._
 import io.circe.Encoder
 import io.circe.syntax._
 import java.time.Instant
@@ -95,7 +96,12 @@ trait Generators {
   def GenSignedEcuManifestWithImage(ecuSerial: EcuSerial, image: Image, custom: Option[CustomManifest] = None): Gen[SignedPayload[EcuManifest]] =
     GenSigned(GenEcuManifestWithImage(ecuSerial, image, custom))
   def GenSignedEcuManifest(ecuSerial: EcuSerial, custom: Option[CustomManifest] = None): Gen[SignedPayload[EcuManifest]] = GenSigned(GenEcuManifest(ecuSerial, custom))
-  def GenSignedDeviceManifest(primeEcu: EcuSerial, ecusManifests: Seq[SignedPayload[EcuManifest]]) = GenSignedValue(DeviceManifest(primeEcu, ecusManifests))
+
+  def GenSignedDeviceManifest(primeEcu: EcuSerial, ecusManifests: Seq[SignedPayload[EcuManifest]]) =
+    GenSignedValue(DeviceManifest(primeEcu, ecusManifests.map{ secuMan => secuMan.signed.ecu_serial -> secuMan.asJson}.toMap))
+
+  def GenSignedDeviceManifest(primeEcu: EcuSerial, ecusManifests: Map[EcuSerial, SignedPayload[EcuManifest]]) =
+    GenSignedValue(DeviceManifest(primeEcu, ecusManifests.map{case (k, v) => k -> v.asJson}))
 
   def genIdentifier(maxLen: Int): Gen[String] = for {
   //use a minimum length of 10 to reduce possibility of naming conflicts


### PR DESCRIPTION
This change is made to be more compliant with the uptane spec, we still
accept the old format for backward compatability reasons.

Also note that we at the device manifest level don't require that what
is in the ecu-manifest actually is an ecu-manifest. This is checked
later in the verifcation of the device-manifest. This is so that an
error in one of the ecu-manifests doesn't break the whole device
manifest.