### PR TITLE
[PRO-3581] targets.json version should increase

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/db/DeviceUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/DeviceUpdate.scala
@@ -72,7 +72,8 @@ object DeviceUpdate extends AdminRepositorySupport
     val dbAct = for {
       latestVersion <- adminRepository.getLatestScheduledVersion(namespace, device)
       nextTimestampVersion = latestVersion + 1
-      fcr = FileCacheRequest(namespace, version, device, None, FileCacheRequestStatus.PENDING, nextTimestampVersion)
+      _ <- adminRepository.copyTargetsAction(namespace, device, version, nextTimestampVersion)
+      fcr = FileCacheRequest(namespace, nextTimestampVersion, device, None, FileCacheRequestStatus.PENDING, nextTimestampVersion)
       _ <- deviceRepository.updateDeviceVersionAction(device, nextTimestampVersion)
       _ <- fileCacheRequestRepository.persistAction(fcr)
     } yield (latestVersion)


### PR DESCRIPTION
When something goes wrong the director sets the new target whawt the
device had before the errorneous update. The way this happened was
that a new timestamp.json was created that pointed to the older
target.json version. But this is not correct, we need to create a new
version of the target.json, with the new version number.