### PR TITLE
[PRO-3526] add auto update

### DIFF
--- a/src/main/resources/db/migration/V13__add_autoupdate.sql
+++ b/src/main/resources/db/migration/V13__add_autoupdate.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `auto_updates` (
+  `namespace` varchar(200) NOT NULL,
+  `device` char(36) NOT NULL,
+  `ecu_serial` varchar(64) NOT NULL REFERENCES ecus(ecu_serial),
+  `target_name` varchar(100) NOT NULL
+) DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/src/main/scala/com/advancedtelematic/director/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/Codecs.scala
@@ -83,6 +83,9 @@ object Codecs {
 
   implicit val queueResponseEncoder: Encoder[QueueResponse] = deriveEncoder
   implicit val queueResponseDecoder: Decoder[QueueResponse] = deriveDecoder
+
+  implicit val autoUpdateEncoder: Encoder[AutoUpdate] = deriveEncoder
+  implicit val autoUpdateDecoder: Decoder[AutoUpdate] = deriveDecoder
 }
 
 object AkkaHttpUnmarshallingSupport {

--- a/src/main/scala/com/advancedtelematic/director/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/DataType.scala
@@ -5,7 +5,7 @@ import com.advancedtelematic.libats.codecs.CirceEnum
 import com.advancedtelematic.libats.data.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.{EcuSerial, DeviceId, TargetFilename, UpdateId}
 import com.advancedtelematic.libtuf.data.ClientDataType.{ClientHashes => Hashes}
-import com.advancedtelematic.libtuf.data.TufDataType.{Checksum, HardwareIdentifier, RepoId, RoleType, TufKey}
+import com.advancedtelematic.libtuf.data.TufDataType.{Checksum, HardwareIdentifier, RepoId, RoleType, TargetName, TufKey}
 import io.circe.Json
 import java.time.Instant
 
@@ -96,4 +96,5 @@ object DataType {
   final case class LaunchedMultiTargetUpdate(device: DeviceId, update: UpdateId, timestampVersion: Int,
                                              status: LaunchedMultiTargetUpdateStatus.Status)
 
+  final case class AutoUpdate(namespace: Namespace, device: DeviceId, ecuSerial: EcuSerial, targetName: TargetName)
 }

--- a/src/main/scala/com/advancedtelematic/director/db/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Errors.scala
@@ -64,4 +64,6 @@ object Errors {
 
   val MissingDevice = RawError(ErrorCodes.MissingDevice, StatusCodes.NotFound, "The device is not found")
   val MissingEcu = MissingEntity[Ecu]
+
+  val ConflictingAutoUpdate = EntityAlreadyExists[AutoUpdate]
 }

--- a/src/main/scala/com/advancedtelematic/director/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Schema.scala
@@ -9,7 +9,7 @@ import com.advancedtelematic.libats.data.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, HashMethod, TargetFilename, UpdateId, ValidChecksum}
 import com.advancedtelematic.libats.messaging_datatype.DataType.HashMethod.HashMethod
 import com.advancedtelematic.libtuf.crypt.TufCrypto
-import com.advancedtelematic.libtuf.data.TufDataType.{Checksum, HardwareIdentifier, KeyType, RepoId, TufKey}
+import com.advancedtelematic.libtuf.data.TufDataType.{Checksum, HardwareIdentifier, KeyType, RepoId, TargetName, TufKey}
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
 import eu.timepit.refined.api.Refined
 import io.circe.Json
@@ -215,4 +215,15 @@ object Schema {
   }
 
   protected [db] val updateTypes = TableQuery[UpdateTypes]
+
+  class AutoUpdates(tag: Tag) extends Table[AutoUpdate](tag, "auto_updates") {
+    def namespace = column[Namespace]("namespace")
+    def device = column[DeviceId]("device")
+    def ecuSerial = column[EcuSerial]("ecu_serial")
+    def targetName = column[TargetName]("target_name")
+
+    override def * = (namespace, device, ecuSerial, targetName) <>
+      ((AutoUpdate.apply _).tupled, AutoUpdate.unapply)
+  }
+  protected [db] val autoUpdates = TableQuery[AutoUpdates]
 }

--- a/src/main/scala/com/advancedtelematic/director/http/AdminResource.scala
+++ b/src/main/scala/com/advancedtelematic/director/http/AdminResource.scala
@@ -3,21 +3,24 @@ package com.advancedtelematic.director.http
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.PathMatcher1
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.Materializer
 import com.advancedtelematic.director.data.AdminRequest.{FindAffectedRequest, RegisterDevice, SetTarget}
 import com.advancedtelematic.director.data.AkkaHttpUnmarshallingSupport._
 import com.advancedtelematic.director.data.Codecs._
-import com.advancedtelematic.director.db.{AdminRepositorySupport, DeviceRepositorySupport, FileCacheRequestRepositorySupport, RepoNameRepositorySupport,
+import com.advancedtelematic.director.db.{AdminRepositorySupport, AutoUpdateRepositorySupport, DeviceRepositorySupport, FileCacheRequestRepositorySupport, RepoNameRepositorySupport,
   SetMultiTargets, SetTargets}
 import com.advancedtelematic.director.repo.DirectorRepo
 import com.advancedtelematic.libats.codecs.AkkaCirce._
 import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.RefinedUtils._
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
-import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, UpdateId}
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, UpdateId, ValidEcuSerial}
 import com.advancedtelematic.libtuf.keyserver.KeyserverClient
 import com.advancedtelematic.libtuf.data.TufCodecs._
+import com.advancedtelematic.libtuf.data.TufDataType.TargetName
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import scala.concurrent.ExecutionContext
 import scala.async.Async._
@@ -27,12 +30,16 @@ class AdminResource(extractNamespace: Directive1[Namespace],
                     keyserverClient: KeyserverClient)
                    (implicit db: Database, ec: ExecutionContext, mat: Materializer, messageBusPublisher: MessageBusPublisher)
     extends AdminRepositorySupport
+    with AutoUpdateRepositorySupport
     with DeviceRepositorySupport
     with FileCacheRequestRepositorySupport
     with RepoNameRepositorySupport {
 
   val directorRepo = new DirectorRepo(keyserverClient)
   val setMultiTargets = new SetMultiTargets()
+
+  val EcuSerialPath = Segment.flatMap(_.refineTry[ValidEcuSerial].toOption)
+  val TargetNamePath: PathMatcher1[TargetName] = Segment.map(TargetName.apply)
 
   def createRepo(namespace: Namespace): Route = complete {
     directorRepo.findOrCreate(namespace).map(StatusCodes.Created -> _)
@@ -113,66 +120,104 @@ class AdminResource(extractNamespace: Directive1[Namespace],
     adminRepository.findQueue(namespace, device)
   }
 
+  def autoUpdateRoute(ns: Namespace, device: DeviceId, ecuSerial: EcuSerial): Route =
+    pathPrefix("auto_update") {
+      pathEnd {
+        get {
+          complete { autoUpdateRepository.findOnDevice(ns, device, ecuSerial) }
+        } ~
+        delete {
+          complete { autoUpdateRepository.removeAll(ns, device, ecuSerial) }
+        }
+      } ~
+      path(TargetNamePath) { targetName =>
+        put {
+          complete { autoUpdateRepository.persist(ns, device, ecuSerial, targetName) }
+        } ~
+        delete {
+          complete { autoUpdateRepository.remove(ns, device, ecuSerial, targetName) }
+        }
+      }
+    }
+
+  def repoRoute(ns: Namespace): Route =
+    pathPrefix("repo") {
+      (pathEnd & post) {
+        createRepo(ns)
+      } ~
+      (path("root.json") & get) {
+        fetchRoot(ns)
+      }
+    }
+
+  def ecusPath(ns: Namespace, device: DeviceId): Route =
+    pathPrefix("ecus") {
+      pathPrefix(EcuSerialPath) { ecuSerial =>
+        autoUpdateRoute(ns, device, ecuSerial) ~
+        (path("public_key") & get) {
+          getPublicKey(ns, device, ecuSerial)
+        }
+      } ~
+      (path("public_key") & parameters('ecu_serial.as[EcuSerial])) { ecuSerial =>
+        getPublicKey(ns, device, ecuSerial)
+      }
+    }
+
+  def devicePath(ns: Namespace): Route =
+    pathPrefix(DeviceId.Path) { device =>
+      ecusPath(ns, device) ~
+      (pathEnd & get) {
+        getDevice(ns, device)
+      } ~
+      (path("images") & get) {
+        listInstalledImages(ns, device)
+      } ~
+      (path("queue") & get) {
+        queueForDevice(ns, device)
+      } ~
+      path("targets") {
+        (put & entity(as[SetTarget])) { targets =>
+          setTargets(ns, device, targets)
+        }
+      } ~
+      path("multi_target_update" / UpdateId.Path) { updateId =>
+        put {
+          setMultiUpdateTarget(ns, device, updateId)
+        }
+      }
+    }
+
+  def multiTargetUpdatesRoute(ns: Namespace): Route =
+    pathPrefix("multi_target_updates" / UpdateId.Path) { updateId =>
+      (pathEnd & put & entity(as[Seq[DeviceId]])) { devices =>
+        setMultiTargetUpdateForDevices(ns, devices, updateId)
+      } ~
+        (path("affected") & get & entity(as[Seq[DeviceId]])) { devices =>
+        findMultiTargetUpdateAffectedDevices(ns, devices, updateId)
+      }
+    }
+
   val route: Route = extractNamespace { ns =>
     pathPrefix("admin") {
       // this is deprecated, should use repo/root.json
       (get & path("root.json")) {
          fetchRoot(ns)
       } ~
-      pathPrefix("repo") {
-        (get & path("root.json")) {
-          fetchRoot(ns)
-        } ~
-        (post & pathEnd) {
-          createRepo(ns)
-        }
-      } ~
+      repoRoute(ns) ~
       pathPrefix("images") {
         (get & path("affected")) {
           findAffectedDevices(ns)
         }
       } ~
-      pathPrefix("multi_target_updates" / UpdateId.Path) { updateId =>
-        (put & entity(as[Seq[DeviceId]])) { devices =>
-          setMultiTargetUpdateForDevices(ns, devices, updateId)
-        } ~
-        (get & path("affected") & entity(as[Seq[DeviceId]])) { devices =>
-          findMultiTargetUpdateAffectedDevices(ns, devices, updateId)
-        }
-      } ~
+      multiTargetUpdatesRoute(ns) ~
       pathPrefix("devices") {
-        (post & entity(as[RegisterDevice]))  { regDev =>
+        (pathEnd & post & entity(as[RegisterDevice]))  { regDev =>
           registerDevice(ns, regDev)
         } ~
         (get & path("hardware_identifiers")) {
           findHardwareIdentifiers(ns)
         } ~
-        pathPrefix(DeviceId.Path) { device =>
-          get {
-            pathEnd {
-              getDevice(ns, device)
-            } ~
-            (path("ecus" / "public_key") & parameters('ecu_serial.as[EcuSerial])) { ecuSerial =>
-              getPublicKey(ns, device, ecuSerial)
-            } ~
-            path("images") {
-              listInstalledImages(ns, device)
-            } ~
-            path("queue") {
-              queueForDevice(ns, device)
-            }
-          } ~
-          path("targets") {
-            (put & entity(as[SetTarget])) { targets =>
-              setTargets(ns, device, targets)
-            }
-          } ~
-          path("multi_target_update" / UpdateId.Path) { updateId =>
-            put {
-              setMultiUpdateTarget(ns, device, updateId)
-            }
-          }
-        }
+        devicePath(ns)
       }
     }
   }

--- a/src/test/scala/com/advancedtelematic/director/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/Generators.scala
@@ -111,6 +111,10 @@ trait Generators {
     name <- Gen.containerOfN[Seq, Char](size, Gen.alphaNumChar)
   } yield name.mkString
 
+  val GenTargetName: Gen[TargetName] = for {
+    target <- genIdentifier(100)
+  } yield TargetName(target)
+
   val GenTargetUpdate: Gen[TargetUpdate] = for {
     target <- genIdentifier(200).map(Refined.unsafeApply[String, ValidTargetFilename])
     size <- Gen.chooseNum(0, Long.MaxValue)

--- a/src/test/scala/com/advancedtelematic/director/http/AutoUpdateSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/AutoUpdateSpec.scala
@@ -1,0 +1,126 @@
+package com.advancedtelematic.director.http
+
+import akka.http.scaladsl.model.StatusCodes
+import cats.syntax.show._
+import com.advancedtelematic.director.data.AdminRequest._
+import com.advancedtelematic.director.data.GeneratorOps._
+import com.advancedtelematic.director.util.{DirectorSpec, ResourceSpec}
+import com.advancedtelematic.director.util.NamespaceTag._
+import com.advancedtelematic.libats.codecs.CirceAnyVal._
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial}
+import com.advancedtelematic.libtuf.data.TufDataType.TargetName
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+
+class AutoUpdateSpec extends DirectorSpec with Requests with ResourceSpec {
+
+  def findAutoUpdate(device: DeviceId, ecuSerial: EcuSerial)(implicit ns: NamespaceTag): Seq[TargetName] =
+    Get(apiUri(s"admin/devices/${device.show}/ecus/${ecuSerial.value}/auto_update")).namespaced ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+      responseAs[Seq[TargetName]]
+    }
+
+  def deleteAllAutoUpdate(device: DeviceId, ecuSerial: EcuSerial)(implicit ns: NamespaceTag): Unit =
+    Delete(apiUri(s"admin/devices/${device.show}/ecus/${ecuSerial.value}/auto_update")).namespaced ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+    }
+
+  def setAutoUpdate(device: DeviceId, ecuSerial: EcuSerial, target: TargetName)(implicit ns: NamespaceTag): Unit = {
+    Put(apiUri(s"admin/devices/${device.show}/ecus/${ecuSerial.value}/auto_update/${target.value}")).namespaced ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
+  def deleteAutoUpdate(device: DeviceId, ecuSerial: EcuSerial, target: TargetName)(implicit ns: NamespaceTag): Unit = {
+    Delete(apiUri(s"admin/devices/${device.show}/ecus/${ecuSerial.value}/auto_update/${target.value}")).namespaced ~> routes ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
+  def regDevice(howManyEcus: Int)(implicit ns: NamespaceTag): (DeviceId, EcuSerial, Seq[EcuSerial]) = {
+    val device = DeviceId.generate
+    val regEcus = (0 until (1 + howManyEcus)).map { _ =>
+      GenRegisterEcu.generate
+    }
+
+    val primEcu = regEcus.head.ecu_serial
+
+    registerDevice(RegisterDevice(device, primEcu, regEcus)).namespaced ~> routes ~> check {
+      status shouldBe StatusCodes.Created
+    }
+
+    (device, primEcu, regEcus.tail.map(_.ecu_serial))
+  }
+
+  test("fetching non-existent autoupdate yield empty") {
+    withRandomNamespace { implicit ns =>
+      val device = DeviceId.generate
+      val ecuSerial= GenEcuSerial.generate
+
+      findAutoUpdate(device, ecuSerial) shouldBe Seq()
+    }
+  }
+
+  test("setting/unsetting targetName shows up") {
+    withRandomNamespace { implicit ns =>
+      val (device, primEcu, ecus) = regDevice(0)
+
+      val targetName = GenTargetName.generate
+
+      setAutoUpdate(device, primEcu, targetName)
+
+      findAutoUpdate(device, primEcu) shouldBe Seq(targetName)
+
+      deleteAutoUpdate(device, primEcu, targetName)
+
+      findAutoUpdate(device, primEcu) shouldBe Seq()
+    }
+  }
+
+  test("multiple ecus can have auto updates") {
+    withRandomNamespace { implicit ns =>
+      val (device, primEcu, Seq(ecu1, ecu2)) = regDevice(2)
+
+      val targetName = GenTargetName.generate
+
+      setAutoUpdate(device, ecu1, targetName)
+      setAutoUpdate(device, ecu2, targetName)
+
+      findAutoUpdate(device, ecu1) shouldBe Seq(targetName)
+      findAutoUpdate(device, ecu2) shouldBe Seq(targetName)
+
+      deleteAutoUpdate(device, ecu1, targetName)
+      deleteAutoUpdate(device, ecu2, targetName)
+
+      findAutoUpdate(device, ecu1) shouldBe Seq()
+      findAutoUpdate(device, ecu2) shouldBe Seq()
+    }
+  }
+
+  test("ecu can have multiple auto updates") {
+    withRandomNamespace { implicit ns =>
+      val (device, primEcu, ecus) = regDevice(0)
+
+      val targetName1 = GenTargetName.generate
+      val targetName2 = GenTargetName.generate
+
+      setAutoUpdate(device, primEcu, targetName1)
+      setAutoUpdate(device, primEcu, targetName2)
+
+      findAutoUpdate(device, primEcu).toSet shouldBe Set(targetName1, targetName2)
+
+      deleteAutoUpdate(device, primEcu, targetName1)
+      findAutoUpdate(device, primEcu) shouldBe Seq(targetName2)
+
+      deleteAutoUpdate(device, primEcu, targetName2)
+      findAutoUpdate(device, primEcu) shouldBe Seq()
+
+      setAutoUpdate(device, primEcu, targetName1)
+      setAutoUpdate(device, primEcu, targetName2)
+      findAutoUpdate(device, primEcu).toSet shouldBe Set(targetName1, targetName2)
+
+      deleteAllAutoUpdate(device, primEcu)
+      findAutoUpdate(device, primEcu) shouldBe Seq()
+    }
+
+  }
+}


### PR DESCRIPTION
An ecu can be associated with an TargetName, for performing auto
updates. This commit only adds the end-points to add/remove and fetch
with ecus have auto updates. A separate ticket will add a kafka-listener
for new targets to schedule new updates.

I also re-factored the routes in the admin interface to group things better.