### PR TITLE
Use correct field name ecuIdentifier in custom

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/DataType.scala
@@ -42,7 +42,7 @@ object DataType {
 
   final case class DiffInfo(checksum: Checksum, size: Long, url: Uri)
 
-  final case class TargetCustom(ecu_serial: EcuSerial, hardwareId: HardwareIdentifier, uri: Uri, diff: Option[DiffInfo])
+  final case class TargetCustom(ecuIdentifier: EcuSerial, hardwareId: HardwareIdentifier, uri: Uri, diff: Option[DiffInfo])
 
   final case class Ecu(ecuSerial: EcuSerial, device: DeviceId, namespace: Namespace, primary: Boolean,
                        hardwareId: HardwareIdentifier, tufKey: TufKey) {


### PR DESCRIPTION
In my big refactoring I accidently named it `ecu_serial` rather than `ecuIdentifier` in the custom field.