### PR TITLE
[PRO-3625] dont accept nonexistant update

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/db/DeviceUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/DeviceUpdate.scala
@@ -1,7 +1,6 @@
 package com.advancedtelematic.director.db
 
-import com.advancedtelematic.director.data.DataType.{FileCacheRequest, Image}
-import com.advancedtelematic.director.data.FileCacheRequestStatus
+import com.advancedtelematic.director.data.DataType.Image
 import com.advancedtelematic.director.data.DeviceRequest.EcuManifest
 import com.advancedtelematic.libats.data.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, UpdateId}
@@ -13,9 +12,10 @@ import slick.jdbc.MySQLProfile.api._
 object DeviceUpdateResult {
   sealed abstract class DeviceUpdateResult
 
-  final case class NoChange() extends DeviceUpdateResult
+  final case object NoChange extends DeviceUpdateResult
   final case class UpdatedSuccessfully(timestamp: Int, updateId: Option[UpdateId]) extends DeviceUpdateResult
-  final case class UpdatedToWrongTarget(timestamp: Int, targets: Map[EcuSerial, Image], manifest: Map[EcuSerial, Image]) extends DeviceUpdateResult
+  // the Option on targets is if the device have targets or not
+  final case class UpdatedToWrongTarget(timestamp: Int, targets: Option[Map[EcuSerial, Image]], manifest: Map[EcuSerial, Image]) extends DeviceUpdateResult
 
 }
 
@@ -26,21 +26,26 @@ object DeviceUpdate extends AdminRepositorySupport
 
   private lazy val _log = LoggerFactory.getLogger(this.getClass)
 
-  final case class DeviceVersion(current: Int, latestUpdate: Option[Int])
+  def subMap[K, V](xs: Map[K,V], ys: Map[K,V]): Boolean = xs.forall {
+    case (k,v) => ys.get(k).contains(v)
+  }
 
   private def isEqualToUpdate(namespace: Namespace, device: DeviceId, next_version: Int, translatedManifest: Map[EcuSerial, Image])
-                             (ifNot : Map[EcuSerial, Image] => DBIO[DeviceUpdateResult])
+                             (ifNot : Option[Map[EcuSerial, Image]] => DBIO[DeviceUpdateResult])
                              (implicit db: Database, ec: ExecutionContext): DBIO[DeviceUpdateResult] =
-    adminRepository.fetchTargetVersionAction(namespace, device, next_version).flatMap { targets =>
-      val translatedTargets = targets.mapValues(_.image)
-      if (translatedTargets == translatedManifest) {
-        for {
-          _ <- deviceRepository.updateDeviceVersionAction(device, next_version)
-          updateId <- adminRepository.fetchUpdateIdAction(namespace, device, next_version)
-        } yield UpdatedSuccessfully(next_version, updateId)
-      } else {
-        ifNot(translatedTargets)
+    adminRepository.updateExistsAction(namespace, device, next_version).flatMap {
+      case true => adminRepository.fetchTargetVersionAction(namespace, device, next_version).flatMap { targets =>
+        val translatedTargets = targets.mapValues(_.image)
+        if (subMap(translatedTargets, translatedManifest)) {
+          for {
+            _ <- deviceRepository.updateDeviceVersionAction(device, next_version)
+            updateId <- adminRepository.fetchUpdateIdAction(namespace, device, next_version)
+          } yield UpdatedSuccessfully(next_version, updateId)
+        } else {
+          ifNot(Some(translatedTargets))
+        }
       }
+      case false => ifNot(None)
     }
 
   def checkAgainstTarget(namespace: Namespace, device: DeviceId, ecuImages: Seq[EcuManifest])
@@ -49,16 +54,16 @@ object DeviceUpdate extends AdminRepositorySupport
 
     val dbAct = deviceRepository.getCurrentVersionAction(device).flatMap {
       case None => isEqualToUpdate(namespace, device, 1, translatedManifest) { _ =>
-        deviceRepository.updateDeviceVersionAction(device, 0).map(_ => NoChange())
+        deviceRepository.updateDeviceVersionAction(device, 0).map(_ => NoChange)
       }
       case Some(current_version) =>
         val next_version = current_version + 1
         isEqualToUpdate(namespace, device, next_version, translatedManifest) { translatedTargets =>
-          adminRepository.findImagesAction(namespace, device).flatMap { currentStored =>
+          adminRepository.findImagesAction(namespace, device).map { currentStored =>
             if (currentStored.toMap == translatedManifest) {
-              DBIO.successful(NoChange())
+              NoChange
             } else {
-              DBIO.successful(UpdatedToWrongTarget(current_version, translatedTargets, translatedManifest))
+              UpdatedToWrongTarget(current_version, translatedTargets, translatedManifest)
             }
           }
         }
@@ -68,14 +73,13 @@ object DeviceUpdate extends AdminRepositorySupport
   }
 
   private [db] def clearTargetsFromAction(namespace: Namespace, device: DeviceId, version: Int)
-                                           (implicit db: Database, ec: ExecutionContext): DBIO[Int] = {
+                                         (implicit db: Database, ec: ExecutionContext): DBIO[Int] = {
     val dbAct = for {
       latestVersion <- adminRepository.getLatestScheduledVersion(namespace, device)
       nextTimestampVersion = latestVersion + 1
       _ <- adminRepository.copyTargetsAction(namespace, device, version, nextTimestampVersion)
-      fcr = FileCacheRequest(namespace, nextTimestampVersion, device, None, FileCacheRequestStatus.PENDING, nextTimestampVersion)
+      _ <- adminRepository.updateDeviceTargetsAction(device, None, nextTimestampVersion)
       _ <- deviceRepository.updateDeviceVersionAction(device, nextTimestampVersion)
-      _ <- fileCacheRequestRepository.persistAction(fcr)
     } yield (latestVersion)
 
     dbAct.transactionally

--- a/src/main/scala/com/advancedtelematic/director/db/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Errors.scala
@@ -24,6 +24,7 @@ object ErrorCodes {
   val MissingUpdateType = ErrorCode("missing_update_type")
   val MissingDevice = ErrorCode("missing_device")
   val CouldNotScheduleDevice = ErrorCode("could_not_schedule_device")
+  val NoCacheEntry = ErrorCode("no_cache_entry")
 }
 
 object Errors {
@@ -69,4 +70,6 @@ object Errors {
   val ConflictingAutoUpdate = EntityAlreadyExists[AutoUpdate]
 
   val CouldNotScheduleDevice = RawError(ErrorCodes.CouldNotScheduleDevice, StatusCodes.PreconditionFailed, "Could not schedule update on device")
+
+  val NoCacheEntry = RawError(ErrorCodes.NoCacheEntry, StatusCodes.InternalServerError, "The requested version is not in the cache")
 }

--- a/src/main/scala/com/advancedtelematic/director/manifest/DeviceManifestUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/DeviceManifestUpdate.scala
@@ -54,11 +54,19 @@ class DeviceManifestUpdate(afterUpdate: AfterDeviceManifestUpdate,
   private def clientReportedNoErrors(namespace: Namespace, device: DeviceId, ecuImages: Seq[EcuManifest],
                                      clientReport: Option[Map[EcuSerial, OperationResult]]): Future[DeviceManifestUpdateResult] =
     DeviceUpdate.checkAgainstTarget(namespace, device, ecuImages).map {
-      case DeviceUpdateResult.NoChange() => NoChange()
+      case DeviceUpdateResult.NoChange => NoChange()
       case DeviceUpdateResult.UpdatedSuccessfully(nextVersion, None) => SuccessWithoutUpdateId()
       case DeviceUpdateResult.UpdatedSuccessfully(nextVersion, Some(updateId)) =>
         SuccessWithUpdateId(namespace, device, updateId, nextVersion, clientReport)
-      case DeviceUpdateResult.UpdatedToWrongTarget(currentVersion, targets, manifest) =>
+      case DeviceUpdateResult.UpdatedToWrongTarget(currentVersion, None, manifest) =>
+        _log.error(s"Device ${device.show} updated when no update was available")
+        _log.info {
+          s"""currentVersion: $currentVersion
+             |manifest      : $manifest
+           """.stripMargin
+        }
+        Failed(namespace, device, currentVersion, None)
+      case DeviceUpdateResult.UpdatedToWrongTarget(currentVersion, Some(targets), manifest) =>
         _log.error(s"Device ${device.show} updated to the wrong target")
         _log.info {
           s"""version : ${currentVersion + 1}

--- a/src/test/scala/com/advancedtelematic/director/daemon/FileCacheSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/daemon/FileCacheSpec.scala
@@ -39,8 +39,9 @@ class FileCacheSpec extends DirectorSpec
 
   def isAvailable[T : Decoder : Encoder](device: DeviceId, file: String): SignedPayload[T] =
     Get(apiUri(s"device/${device.show}/$file")) ~> routes ~> check {
+      val resp = responseAs[SignedPayload[T]]
       status shouldBe StatusCodes.OK
-      responseAs[SignedPayload[T]]
+      resp
     }
 
   def beAfter(other: Instant): Matcher[Instant] = new Matcher[Instant] {


### PR DESCRIPTION
The director could be confused between an empty target and non-existant target,
which could cause the device_current_target be higher than
device_update_targets.

Also changed how we check targets, we know accept manifest that are more
specific than the targets (which can be empty).

When rolling back we don't make a file cache request, since this files will be generated on requests anyway.