### PR TITLE
[PRO-3472] check signatures on the received json

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/daemon/CampaignWorker.scala
+++ b/src/main/scala/com/advancedtelematic/director/daemon/CampaignWorker.scala
@@ -3,12 +3,12 @@ package com.advancedtelematic.director.daemon
 import akka.Done
 import akka.http.scaladsl.util.FastFuture
 import com.advancedtelematic.director.data.AdminRequest.SetTarget
-import com.advancedtelematic.director.data.DataType.{CustomImage, FileInfo, Image}
+import com.advancedtelematic.director.data.DataType.{CustomImage, FileInfo, Hashes, Image}
 import com.advancedtelematic.director.db.{AdminRepositorySupport, SetTargets, Errors => DBErrors}
 import com.advancedtelematic.libats.codecs.RefinementError
 import com.advancedtelematic.libats.data.Namespace
 import com.advancedtelematic.libats.data.RefinedUtils.RefineTry
-import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, HashMethod, UpdateId, ValidChecksum, ValidTargetFilename}
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId, ValidChecksum, ValidTargetFilename}
 import com.advancedtelematic.libats.messaging_datatype.Messages.CampaignLaunched
 import org.slf4j.LoggerFactory
 
@@ -50,5 +50,5 @@ object CampaignWorker extends AdminRepositorySupport {
   private def getImage(cl: CampaignLaunched): Try[CustomImage] = for {
     hash <- cl.pkgChecksum.refineTry[ValidChecksum]
     filepath <- cl.pkg.mkString.refineTry[ValidTargetFilename]
-  } yield CustomImage(Image(filepath, FileInfo(Map(HashMethod.SHA256 -> hash), cl.pkgSize.toInt)), cl.pkgUri, None)
+  } yield CustomImage(Image(filepath, FileInfo(Hashes(hash), cl.pkgSize.toInt)), cl.pkgUri, None)
 }

--- a/src/main/scala/com/advancedtelematic/director/data/AdminRequest.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/AdminRequest.scala
@@ -3,7 +3,6 @@ package com.advancedtelematic.director.data
 import java.security.PublicKey
 
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, TargetFilename, UpdateId}
-import com.advancedtelematic.libtuf.data.ClientDataType.{ClientHashes => Hashes}
 import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, KeyType, TufKey}
 
 object AdminRequest {

--- a/src/main/scala/com/advancedtelematic/director/data/DeviceRequest.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/DeviceRequest.scala
@@ -1,7 +1,6 @@
 package com.advancedtelematic.director.data
 
 import com.advancedtelematic.libats.messaging_datatype.DataType.EcuSerial
-import com.advancedtelematic.libtuf.data.TufDataType.SignedPayload
 import io.circe.Json
 
 import java.time.Instant
@@ -15,9 +14,6 @@ object DeviceRequest {
                                ecu_serial: EcuSerial,
                                attacks_detected: String,
                                custom: Option[Json] = None)
-
-  final case class LegacyDeviceManifest(primary_ecu_serial: EcuSerial,
-                                        ecu_version_manifest: Seq[SignedPayload[EcuManifest]])
 
   final case class DeviceManifest(primary_ecu_serial: EcuSerial,
                                   ecu_version_manifests: Map[EcuSerial, Json])

--- a/src/main/scala/com/advancedtelematic/director/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Repository.scala
@@ -32,7 +32,7 @@ protected class AdminRepository()(implicit db: Database, ec: ExecutionContext) e
     with FileCacheRequestRepositorySupport
     with UpdateTypesRepositorySupport {
   import com.advancedtelematic.director.data.AdminRequest.{EcuInfoResponse, EcuInfoImage, RegisterEcu, QueueResponse}
-  import com.advancedtelematic.director.data.DataType.{CustomImage, DeviceUpdateTarget, Image}
+  import com.advancedtelematic.director.data.DataType.{CustomImage, DeviceUpdateTarget, Hashes, Image}
   import com.advancedtelematic.libtuf.data.TufSlickMappings._
 
   implicit private class NotInCampaign(query: Query[Rep[DeviceId], DeviceId, Seq]) {
@@ -105,7 +105,7 @@ protected class AdminRepository()(implicit db: Database, ec: ExecutionContext) e
       devices <- query.result.failIfEmpty(MissingDevice)
     } yield for {
       (id, hardwareId, primary, filepath, size, checksum) <- devices
-    } yield EcuInfoResponse(id, hardwareId, primary, EcuInfoImage(filepath, size, Map(checksum.method -> checksum.hash)))
+    } yield EcuInfoResponse(id, hardwareId, primary, EcuInfoImage(filepath, size, Hashes(checksum.hash)))
   }
 
   def findPublicKey(namespace: Namespace, device: DeviceId, ecu_serial: EcuSerial): Future[TufKey] = db.run {

--- a/src/main/scala/com/advancedtelematic/director/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Schema.scala
@@ -71,8 +71,8 @@ object Schema {
     def ecuFK = foreignKey("ECU_FK", id, ecu)(_.ecuSerial)
 
     def fileInfo = (checksum, length) <>
-      ( { case (checksum, length) => FileInfo(Map(checksum.method -> checksum.hash), length)},
-        (x: FileInfo) => Some((Checksum(HashMethod.SHA256, x.hashes(HashMethod.SHA256)), x.length))
+      ( { case (checksum, length) => FileInfo(Hashes(checksum.hash), length)},
+        (x: FileInfo) => Some((Checksum(HashMethod.SHA256, x.hashes.sha256), x.length))
       )
     def image = (filepath, fileInfo) <> ((Image.apply _).tupled, Image.unapply)
 
@@ -104,8 +104,8 @@ object Schema {
     def primKey = primaryKey("ecu_target_pk", (namespace, version, id))
 
     def fileInfo = (checksum, length) <>
-      ( { case (checksum, length) => FileInfo(Map(checksum.method -> checksum.hash), length)},
-        (x: FileInfo) => Some((Checksum(HashMethod.SHA256, x.hashes(HashMethod.SHA256)), x.length))
+      ( { case (checksum, length) => FileInfo(Hashes(checksum.hash), length)},
+        (x: FileInfo) => Some((Checksum(HashMethod.SHA256, x.hashes.sha256), x.length))
       )
 
     def image = (filepath, fileInfo) <> ((Image.apply _).tupled, Image.unapply)

--- a/src/main/scala/com/advancedtelematic/director/http/DeviceResource.scala
+++ b/src/main/scala/com/advancedtelematic/director/http/DeviceResource.scala
@@ -3,7 +3,7 @@ package com.advancedtelematic.director.http
 import akka.http.scaladsl.server.{Directive0, Directive1}
 import com.advancedtelematic.director.client.CoreClient
 import com.advancedtelematic.director.data.Codecs._
-import com.advancedtelematic.director.data.DeviceRequest.{DeviceManifest, DeviceRegistration, LegacyDeviceManifest}
+import com.advancedtelematic.director.data.DeviceRequest.DeviceRegistration
 import com.advancedtelematic.director.db.{DeviceRepositorySupport, FileCacheRepositorySupport, RepoNameRepositorySupport}
 import com.advancedtelematic.director.manifest.Verifier.Verifier
 import com.advancedtelematic.director.manifest.{AfterDeviceManifestUpdate, DeviceManifestUpdate}
@@ -16,6 +16,7 @@ import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.{RoleType, SignedPayload, TufKey}
 import com.advancedtelematic.libtuf.keyserver.KeyserverClient
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import io.circe.Json
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.ExecutionContext
@@ -68,11 +69,8 @@ class DeviceResource(extractNamespace: Directive1[Namespace],
       } ~
       put {
         (path("manifest") & logDevice(ns, device)) {
-          entity(as[SignedPayload[DeviceManifest]]) { devMan =>
-            complete(deviceManifestUpdate.setDeviceManifest(ns, device, devMan))
-          } ~
-          entity(as[SignedPayload[LegacyDeviceManifest]]) { devMan =>
-            complete(deviceManifestUpdate.setLegacyDeviceManifest(ns, device, devMan))
+          entity(as[SignedPayload[Json]]) { jsonDevMan =>
+            complete(deviceManifestUpdate.setDeviceManifest(ns, device, jsonDevMan))
           }
         }
       } ~

--- a/src/main/scala/com/advancedtelematic/director/roles/RolesGeneration.scala
+++ b/src/main/scala/com/advancedtelematic/director/roles/RolesGeneration.scala
@@ -45,7 +45,7 @@ class RolesGeneration(tuf: KeyserverClient, diffService: DiffServiceClient)
     val clientsTarget = targets.map { case (ecu_serial, TargetCustomImage(image, hardware, uri, diff)) =>
       val targetCustom = TargetCustom(ecu_serial, hardware, uri, diff)
 
-      image.filepath -> ClientTargetItem(image.fileinfo.hashes, image.fileinfo.length,
+      image.filepath -> ClientTargetItem(image.fileinfo.hashes.toClientHashes, image.fileinfo.length,
                                          Some(targetCustom.asJson))
     }
 
@@ -77,7 +77,7 @@ class RolesGeneration(tuf: KeyserverClient, diffService: DiffServiceClient)
   } yield Done
 
   private def fromImage(image: Image): TargetUpdate = {
-    val checksum = Checksum(HashMethod.SHA256, image.fileinfo.hashes(HashMethod.SHA256))
+    val checksum = Checksum(HashMethod.SHA256, image.fileinfo.hashes.sha256)
     TargetUpdate(image.filepath, checksum, image.fileinfo.length)
   }
 

--- a/src/test/scala/com/advancedtelematic/director/data/Legacy.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/Legacy.scala
@@ -1,0 +1,11 @@
+package com.advancedtelematic.director.data
+
+import com.advancedtelematic.director.data.DeviceRequest.EcuManifest
+import com.advancedtelematic.libats.messaging_datatype.DataType.EcuSerial
+import com.advancedtelematic.libtuf.data.TufDataType.SignedPayload
+
+object Legacy {
+  final case class LegacyDeviceManifest(primary_ecu_serial: EcuSerial,
+                                        ecu_version_manifest: Seq[SignedPayload[EcuManifest]])
+
+}

--- a/src/test/scala/com/advancedtelematic/director/data/TestCodecs.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/TestCodecs.scala
@@ -1,0 +1,20 @@
+package com.advancedtelematic.director.data
+
+import com.advancedtelematic.director.data.Codecs._
+import com.advancedtelematic.director.data.DeviceRequest.DeviceManifest
+import com.advancedtelematic.director.data.Legacy.LegacyDeviceManifest
+import com.advancedtelematic.libats.codecs.AkkaCirce._
+import com.advancedtelematic.libtuf.data.RefinedStringEncoding._
+import com.advancedtelematic.libtuf.data.TufCodecs._
+
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto._
+
+object TestCodecs {
+
+  implicit val encoderDeviceManifest: Encoder[DeviceManifest] = deriveEncoder
+
+  implicit val encoderLegacyDeviceManifest: Encoder[LegacyDeviceManifest] = deriveEncoder
+  implicit val decoderLegacyDeviceManifest: Decoder[LegacyDeviceManifest] = deriveDecoder
+
+}

--- a/src/test/scala/com/advancedtelematic/director/http/NamespacedRequests.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/NamespacedRequests.scala
@@ -6,7 +6,8 @@ import cats.syntax.show._
 import com.advancedtelematic.director.data.AdminRequest.{EcuInfoResponse, FindImageCount, QueueResponse, RegisterDevice, SetTarget}
 import com.advancedtelematic.director.data.Codecs._
 import com.advancedtelematic.director.data.DataType.{Image, MultiTargetUpdateRequest}
-import com.advancedtelematic.director.data.DeviceRequest.{DeviceManifest, LegacyDeviceManifest}
+import com.advancedtelematic.director.data.Legacy.LegacyDeviceManifest
+import com.advancedtelematic.director.data.TestCodecs._
 import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, ResourceSpec}
 import com.advancedtelematic.director.util.NamespaceTag._
 import com.advancedtelematic.libats.codecs.AkkaCirce._
@@ -46,18 +47,18 @@ trait NamespacedRequests extends DirectorSpec with DefaultPatience with Resource
       status shouldBe StatusCodes.OK
     }
 
-  def updateManifest(device: DeviceId, manifest: SignedPayload[DeviceManifest])(implicit ns: NamespaceTag): HttpRequest =
+  def updateManifest(device: DeviceId, manifest: SignedPayload[Json])(implicit ns: NamespaceTag): HttpRequest =
     Put(apiUri(s"device/${device.show}/manifest"), manifest).namespaced
 
-  def updateManifestOk(device: DeviceId, manifest: SignedPayload[DeviceManifest])(implicit ns: NamespaceTag): Unit =
+  def updateManifestOk(device: DeviceId, manifest: SignedPayload[Json])(implicit ns: NamespaceTag): Unit =
     updateManifestOkWith(device, manifest, routes)
 
-  def updateManifestOkWith(device: DeviceId, manifest: SignedPayload[DeviceManifest], withRoutes: Route)(implicit ns: NamespaceTag): Unit =
+  def updateManifestOkWith(device: DeviceId, manifest: SignedPayload[Json], withRoutes: Route)(implicit ns: NamespaceTag): Unit =
     updateManifest(device, manifest) ~> withRoutes ~> check {
       status shouldBe StatusCodes.OK
     }
 
-  def updateManifestExpect(device: DeviceId, manifest: SignedPayload[DeviceManifest], expected: StatusCode)(implicit ns: NamespaceTag): Unit =
+  def updateManifestExpect(device: DeviceId, manifest: SignedPayload[Json], expected: StatusCode)(implicit ns: NamespaceTag): Unit =
     updateManifest(device, manifest) ~> routes ~> check {
       status shouldBe expected
     }

--- a/src/test/scala/com/advancedtelematic/director/http/Requests.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/Requests.scala
@@ -6,7 +6,8 @@ import cats.syntax.show._
 import com.advancedtelematic.director.data.AdminRequest.{RegisterDevice, SetTarget, QueueResponse}
 import com.advancedtelematic.director.data.Codecs._
 import com.advancedtelematic.director.data.DataType.{Image, MultiTargetUpdateRequest, TargetUpdateRequest}
-import com.advancedtelematic.director.data.DeviceRequest.{DeviceManifest, LegacyDeviceManifest}
+import com.advancedtelematic.director.data.Legacy.LegacyDeviceManifest
+import com.advancedtelematic.director.data.TestCodecs._
 import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, ResourceSpec}
 import com.advancedtelematic.director.util.NamespaceTag._
 import com.advancedtelematic.libats.codecs.AkkaCirce._
@@ -15,6 +16,7 @@ import com.advancedtelematic.libtuf.data.RefinedStringEncoding._
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, SignedPayload}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import io.circe.Json
 
 trait Requests extends DirectorSpec with DefaultPatience with ResourceSpec {
   def registerDevice(regDev: RegisterDevice): HttpRequest = Post(apiUri("admin/devices"), regDev)
@@ -38,18 +40,18 @@ trait Requests extends DirectorSpec with DefaultPatience with ResourceSpec {
       status shouldBe StatusCodes.OK
     }
 
-  def updateManifest(device: DeviceId, manifest: SignedPayload[DeviceManifest]): HttpRequest =
+  def updateManifest(device: DeviceId, manifest: SignedPayload[Json]): HttpRequest =
     Put(apiUri(s"device/${device.show}/manifest"), manifest)
 
-  def updateManifestOk(device: DeviceId, manifest: SignedPayload[DeviceManifest]): Unit =
+  def updateManifestOk(device: DeviceId, manifest: SignedPayload[Json]): Unit =
     updateManifestOkWith(device, manifest, routes)
 
-  def updateManifestOkWith(device: DeviceId, manifest: SignedPayload[DeviceManifest], withRoutes: Route): Unit =
+  def updateManifestOkWith(device: DeviceId, manifest: SignedPayload[Json], withRoutes: Route): Unit =
     updateManifest(device, manifest) ~> withRoutes ~> check {
       status shouldBe StatusCodes.OK
     }
 
-  def updateManifestExpect(device: DeviceId, manifest: SignedPayload[DeviceManifest], expected: StatusCode): Unit =
+  def updateManifestExpect(device: DeviceId, manifest: SignedPayload[Json], expected: StatusCode): Unit =
     updateManifest(device, manifest) ~> routes ~> check {
       status shouldBe expected
     }


### PR DESCRIPTION
Previously we parsed the json and then checked, but this causes problems
with checking the signature. So instead the endpoint takes an
SignedPayload[Json], and we check the signature against the Json rather
than the DeviceManifest, which we manually parse from the Json during
verification of the device manifest.

Also I changed the type of the hashes from ClientHashes to my own Hashes
type, that also only accept SHA256 at the moment.

I still don't really know how we want to implement
multiple hashes in the future, but the current Map
forces two things:

1. The server needs to know all hashmethods that a
  client can possibly send (with all what that means
  for backwards compatibility)

2. All hashes need to have the same length as a SHA256
  hash. Because ValidChecksum checks the length, this
  is of course easy to change.