### PR TITLE
bump libtuf version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,8 @@ libraryDependencies ++= {
   val scalaTestV = "3.0.0"
   val sotaV = "0.2.89"
   val bouncyCastleV = "1.57"
-  val tufV = "0.1.0-165-g47373e9"
-  val libatsV = "0.0.1-90-g0bd3fca"
+  val tufV = "0.2.0-1-g5579c30"
+  val libatsV = "0.1.0-5-g6b585f0"
   val circeConfigV = "0.0.2"
 
   Seq(
@@ -36,7 +36,7 @@ libraryDependencies ++= {
     "com.advancedtelematic" %% "libats-metrics-akka" % libatsV,
     "com.advancedtelematic" %% "libats-slick" % libatsV,
     "com.advancedtelematic" %% "libtuf" % tufV,
-    "com.advancedtelematic" %% "libtuf_server" % tufV,
+    "com.advancedtelematic" %% "libtuf-server" % tufV,
     "com.advancedtelematic" %% "circe-config" % circeConfigV,
 
     "org.bouncycastle" % "bcprov-jdk15on" % bouncyCastleV,

--- a/src/main/scala/com/advancedtelematic/diff_service/client/DiffService.scala
+++ b/src/main/scala/com/advancedtelematic/diff_service/client/DiffService.scala
@@ -6,11 +6,11 @@ import com.advancedtelematic.diff_service.data.DataType.CreateDiffInfoRequest
 import com.advancedtelematic.diff_service.db.{BsDiffRepositorySupport, StaticDeltaRepositorySupport}
 import com.advancedtelematic.diff_service.db.Errors._
 import com.advancedtelematic.director.data.DataType.TargetUpdate
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.{Checksum, Namespace}
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
-import com.advancedtelematic.libats.messaging_datatype.DataType.Checksum
 import com.advancedtelematic.libats.messaging_datatype.Messages.{BsDiffRequest, DeltaRequest}
 import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat._
+import java.net.URI
 import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.MySQLProfile.api.Database
 
@@ -60,7 +60,8 @@ class DiffServiceDirectorClient(binaryUri: Uri)
           val id = BsDiffRequestId.generate
           val from = convertToBinaryUri(binaryUri, diffRequest.from)
           val to = convertToBinaryUri(binaryUri, diffRequest.to)
-          messageBusPublisher.publish(BsDiffRequest(id, namespace, from, to)).flatMap { _ =>
+          def toURI(uri: Uri): URI = URI.create(uri.toString)
+          messageBusPublisher.publish(BsDiffRequest(id, namespace, toURI(from), toURI(to))).flatMap { _ =>
             bsdiffRepository.persist(namespace, id, from, to)
           }
       }

--- a/src/main/scala/com/advancedtelematic/diff_service/daemon/DiffListener.scala
+++ b/src/main/scala/com/advancedtelematic/diff_service/daemon/DiffListener.scala
@@ -1,6 +1,7 @@
 package com.advancedtelematic.diff_service.daemon
 
 import akka.Done
+import akka.http.scaladsl.model.Uri
 import cats.syntax.show._
 import com.advancedtelematic.diff_service.data.DataType.DiffStatus
 import com.advancedtelematic.diff_service.db.{BsDiffRepositorySupport, StaticDeltaRepositorySupport}
@@ -17,7 +18,7 @@ class DiffListener (implicit db: Database, ec: ExecutionContext)
   private lazy val _log = LoggerFactory.getLogger(this.getClass)
 
   def generatedDeltaAction(msg: GeneratedDelta): Future[Done] =
-    staticDeltaRepository.persistInfo(msg.namespace, msg.id, msg.uri, msg.size, msg.checksum).map(_ => Done).recover {
+    staticDeltaRepository.persistInfo(msg.namespace, msg.id, Uri(msg.uri.toString), msg.size, msg.checksum).map(_ => Done).recover {
       case ConflictingStaticDeltaInfo =>
         _log.error(s"The info for ${msg.id.show} already exists, ignoring message.")
         Done
@@ -27,7 +28,7 @@ class DiffListener (implicit db: Database, ec: ExecutionContext)
     }
 
   def generatedBsDiffAction(msg: GeneratedBsDiff): Future[Done] =
-    bsdiffRepository.persistInfo(msg.namespace, msg.id, msg.resultUri, msg.size, msg.checksum).map(_ => Done).recover {
+    bsdiffRepository.persistInfo(msg.namespace, msg.id, Uri(msg.resultUri.toString), msg.size, msg.checksum).map(_ => Done).recover {
       case ConflictingBsDiffInfo =>
         _log.error(s"The info for ${msg.id.show} already exists, ignoring message.")
         Done

--- a/src/main/scala/com/advancedtelematic/diff_service/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/diff_service/data/Codecs.scala
@@ -1,13 +1,18 @@
 package com.advancedtelematic.diff_service.data
 
 import com.advancedtelematic.diff_service.data.DataType._
+import com.advancedtelematic.diff_service.data.DataType.DiffStatus.DiffStatus
 import com.advancedtelematic.director.data.Codecs.{decoderTargetUpdate, encoderTargetUpdate}
-import com.advancedtelematic.libats.codecs.AkkaCirce._
-import com.advancedtelematic.libats.messaging_datatype.MessageCodecs._
+import com.advancedtelematic.libats.codecs.CirceCodecs._
+import com.advancedtelematic.libats.http.HttpCodecs._
+import com.advancedtelematic.libtuf.data.ClientCodecs._
 import io.circe.generic.semiauto._
 import io.circe.{Decoder, Encoder}
 
 object Codecs {
+  implicit val decoderDiffStatus: Decoder[DiffStatus] = Decoder.enumDecoder(DiffStatus)
+  implicit val encoderDiffStatus: Encoder[DiffStatus] = Encoder.enumEncoder(DiffStatus)
+
   implicit val decoderCreatDiffInfoRequest: Decoder[CreateDiffInfoRequest] = deriveDecoder
   implicit val encoderCreatDiffInfoRequest: Encoder[CreateDiffInfoRequest] = deriveEncoder
 

--- a/src/main/scala/com/advancedtelematic/diff_service/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/diff_service/data/DataType.scala
@@ -3,14 +3,12 @@ package com.advancedtelematic.diff_service.data
 import akka.http.scaladsl.model.Uri
 import com.advancedtelematic.diff_service.data.DataType.DiffStatus.DiffStatus
 import com.advancedtelematic.director.data.DataType.TargetUpdate
-import com.advancedtelematic.libats.codecs.CirceEnum
-import com.advancedtelematic.libats.data.Namespace
-import com.advancedtelematic.libats.slick.codecs.SlickEnum
-import com.advancedtelematic.libats.messaging_datatype.DataType.{BsDiffRequestId, Checksum, Commit, DeltaRequestId}
+import com.advancedtelematic.libats.data.DataType.{Checksum, Namespace}
+import com.advancedtelematic.libats.messaging_datatype.DataType.{BsDiffRequestId, Commit, DeltaRequestId}
 import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat.TargetFormat
 
 object DataType {
-  object DiffStatus extends CirceEnum with SlickEnum {
+  object DiffStatus extends Enumeration {
     type DiffStatus = Value
 
     val REQUESTED, GENERATED, FAILED = Value

--- a/src/main/scala/com/advancedtelematic/diff_service/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/diff_service/db/Repository.scala
@@ -4,8 +4,9 @@ import akka.http.scaladsl.model.Uri
 import com.advancedtelematic.diff_service.data.DataType.{BsDiff, BsDiffInfo, BsDiffQueryResponse, DiffStatus, StaticDelta, StaticDeltaInfo, StaticDeltaQueryResponse}
 import com.advancedtelematic.diff_service.data.DataType.DiffStatus.DiffStatus
 import com.advancedtelematic.diff_service.db.Errors._
-import com.advancedtelematic.libats.data.Namespace
-import com.advancedtelematic.libats.messaging_datatype.DataType.{BsDiffRequestId, Checksum, Commit, DeltaRequestId}
+import com.advancedtelematic.diff_service.db.SlickMappings._
+import com.advancedtelematic.libats.data.DataType.{Checksum, Namespace}
+import com.advancedtelematic.libats.messaging_datatype.DataType.{BsDiffRequestId, Commit, DeltaRequestId}
 import com.advancedtelematic.libats.slick.codecs.SlickRefined._
 import com.advancedtelematic.libats.slick.db.SlickAnyVal._
 import com.advancedtelematic.libats.slick.db.SlickExtensions._

--- a/src/main/scala/com/advancedtelematic/diff_service/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/diff_service/db/Schema.scala
@@ -1,12 +1,11 @@
 package com.advancedtelematic.diff_service.db
 
 import akka.http.scaladsl.model.Uri
-import com.advancedtelematic.diff_service.data.DataType.{BsDiff, StaticDelta, BsDiffInfo, StaticDeltaInfo}
+import com.advancedtelematic.diff_service.data.DataType.{BsDiff, BsDiffInfo, DiffStatus, StaticDelta, StaticDeltaInfo}
 import com.advancedtelematic.diff_service.data.DataType.DiffStatus.DiffStatus
-import com.advancedtelematic.libats.data.Namespace
-import com.advancedtelematic.libats.messaging_datatype.DataType.{BsDiffRequestId, Checksum, Commit, DeltaRequestId,
-  HashMethod, ValidChecksum}
-import com.advancedtelematic.libats.messaging_datatype.DataType.HashMethod.HashMethod
+import com.advancedtelematic.libats.data.DataType.{Checksum, HashMethod, Namespace, ValidChecksum}
+import com.advancedtelematic.libats.data.DataType.HashMethod.HashMethod
+import com.advancedtelematic.libats.messaging_datatype.DataType.{BsDiffRequestId, Commit, DeltaRequestId}
 import com.advancedtelematic.libats.slick.codecs.SlickRefined._
 import com.advancedtelematic.libats.slick.db.SlickAnyVal._
 import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
@@ -14,7 +13,13 @@ import com.advancedtelematic.libats.slick.db.SlickUriMapper._
 import eu.timepit.refined.api.Refined
 import slick.jdbc.MySQLProfile.api._
 
+object SlickMappings {
+  import com.advancedtelematic.libats.slick.codecs.SlickEnumMapper
+  implicit val diffStatusMapping = SlickEnumMapper.enumMapper(DiffStatus)
+}
+
 object Schema {
+  import SlickMappings._
   // `HashMethod` should extend `SlickEnum`, but until then we have this implicit
   implicit val hashMethodColumn = MappedColumnType.base[HashMethod, String](_.toString, HashMethod.withName)
 

--- a/src/main/scala/com/advancedtelematic/diff_service/http/DiffResource.scala
+++ b/src/main/scala/com/advancedtelematic/diff_service/http/DiffResource.scala
@@ -8,7 +8,7 @@ import com.advancedtelematic.diff_service.client.DiffServiceClient
 import com.advancedtelematic.diff_service.data.DataType.{BsDiffQuery, CreateDiffInfoRequest, StaticDeltaQuery}
 import com.advancedtelematic.diff_service.data.Codecs._
 import com.advancedtelematic.diff_service.db.{BsDiffRepositorySupport, StaticDeltaRepositorySupport}
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import scala.concurrent.ExecutionContext
 import slick.jdbc.MySQLProfile.api.Database

--- a/src/main/scala/com/advancedtelematic/director/Boot.scala
+++ b/src/main/scala/com/advancedtelematic/director/Boot.scala
@@ -9,14 +9,14 @@ import com.advancedtelematic.director.client.CoreHttpClient
 import com.advancedtelematic.director.http.DirectorRoutes
 import com.advancedtelematic.director.manifest.SignatureVerification
 import com.advancedtelematic.director.roles.{Roles, RolesGeneration}
-import com.advancedtelematic.libats.http.{BootApp}
+import com.advancedtelematic.libats.http.BootApp
 import com.advancedtelematic.libats.http.LogDirectives.logResponseMetrics
 import com.advancedtelematic.libats.http.VersionDirectives.versionHeaders
+import com.advancedtelematic.libats.http.monitoring.MetricsSupport
 import com.advancedtelematic.libats.messaging.MessageBus
-import com.advancedtelematic.libats.monitoring.MetricsSupport
 import com.advancedtelematic.libats.slick.db.{BootMigrations, DatabaseConfig}
 import com.advancedtelematic.libats.slick.monitoring.{DatabaseMetrics, DbHealthResource}
-import com.advancedtelematic.libtuf.keyserver.KeyserverHttpClient
+import com.advancedtelematic.libtuf_server.keyserver.KeyserverHttpClient
 import com.advancedtelematic.metrics.{AkkaHttpMetricsSink, InfluxDbMetricsReporter, InfluxDbMetricsReporterSettings, OsMetricSet}
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet
 import com.typesafe.config.{Config, ConfigFactory}

--- a/src/main/scala/com/advancedtelematic/director/client/Core.scala
+++ b/src/main/scala/com/advancedtelematic/director/client/Core.scala
@@ -10,8 +10,8 @@ import akka.stream.Materializer
 import cats.syntax.show.toShowOps
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
 import com.advancedtelematic.director.data.DeviceRequest.OperationResult
-import com.advancedtelematic.libats.data.Namespace
-import com.advancedtelematic.libats.http.ErrorCode
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.data.ErrorCode
 import com.advancedtelematic.libats.http.Errors.RawError
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/main/scala/com/advancedtelematic/director/daemon/CampaignWorker.scala
+++ b/src/main/scala/com/advancedtelematic/director/daemon/CampaignWorker.scala
@@ -1,14 +1,15 @@
 package com.advancedtelematic.director.daemon
 
 import akka.Done
+import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.util.FastFuture
 import com.advancedtelematic.director.data.AdminRequest.SetTarget
 import com.advancedtelematic.director.data.DataType.{CustomImage, FileInfo, Hashes, Image}
 import com.advancedtelematic.director.db.{AdminRepositorySupport, SetTargets, Errors => DBErrors}
 import com.advancedtelematic.libats.codecs.RefinementError
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.{Namespace, ValidChecksum}
 import com.advancedtelematic.libats.data.RefinedUtils.RefineTry
-import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId, ValidChecksum, ValidTargetFilename}
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId, ValidTargetFilename}
 import com.advancedtelematic.libats.messaging_datatype.Messages.CampaignLaunched
 import org.slf4j.LoggerFactory
 
@@ -50,5 +51,5 @@ object CampaignWorker extends AdminRepositorySupport {
   private def getImage(cl: CampaignLaunched): Try[CustomImage] = for {
     hash <- cl.pkgChecksum.refineTry[ValidChecksum]
     filepath <- cl.pkg.mkString.refineTry[ValidTargetFilename]
-  } yield CustomImage(Image(filepath, FileInfo(Hashes(hash), cl.pkgSize.toInt)), cl.pkgUri, None)
+  } yield CustomImage(Image(filepath, FileInfo(Hashes(hash), cl.pkgSize.toInt)), Uri(cl.pkgUri.toString), None)
 }

--- a/src/main/scala/com/advancedtelematic/director/daemon/CreateRepoActor.scala
+++ b/src/main/scala/com/advancedtelematic/director/daemon/CreateRepoActor.scala
@@ -3,7 +3,7 @@ package com.advancedtelematic.director.daemon
 import akka.Done
 import com.advancedtelematic.director.db.Errors.ConflictNamespaceRepo
 import com.advancedtelematic.director.repo.DirectorRepo
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.Messages.UserCreated
 import org.slf4j.LoggerFactory
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/main/scala/com/advancedtelematic/director/daemon/DaemonBoot.scala
+++ b/src/main/scala/com/advancedtelematic/director/daemon/DaemonBoot.scala
@@ -8,14 +8,14 @@ import com.advancedtelematic.director.{Settings, VersionInfo}
 import com.advancedtelematic.director.db.SetMultiTargets
 import com.advancedtelematic.director.repo.DirectorRepo
 import com.advancedtelematic.director.roles.RolesGeneration
-import com.advancedtelematic.libtuf.keyserver.KeyserverHttpClient
 import com.advancedtelematic.libats.slick.db.{BootMigrations, DatabaseConfig}
 import com.advancedtelematic.libats.http.BootApp
+import com.advancedtelematic.libats.http.monitoring.MetricsSupport
 import com.advancedtelematic.libats.messaging.{BusListenerMetrics, MessageBus, MessageListenerSupport}
 import com.advancedtelematic.libats.messaging_datatype.Messages.{BsDiffGenerationFailed, CampaignLaunched, DeltaGenerationFailed, GeneratedBsDiff, GeneratedDelta, UserCreated}
-import com.advancedtelematic.libats.monitoring.MetricsSupport
 import com.advancedtelematic.libats.slick.monitoring.{DatabaseMetrics, DbHealthResource}
-import com.advancedtelematic.libtuf.data.Messages.TufTargetAdded
+import com.advancedtelematic.libtuf_server.data.Messages.TufTargetAdded
+import com.advancedtelematic.libtuf_server.keyserver.KeyserverHttpClient
 import com.advancedtelematic.metrics.{AkkaHttpMetricsSink, InfluxDbMetricsReporter}
 
 object DaemonBoot extends BootApp

--- a/src/main/scala/com/advancedtelematic/director/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/Codecs.scala
@@ -4,12 +4,13 @@ import cats.instances.list._
 import cats.instances.either._
 import cats.syntax.traverse._
 import com.advancedtelematic.director.data.DataType._
-import com.advancedtelematic.libats.codecs.AkkaCirce._
+import com.advancedtelematic.libats.codecs.CirceCodecs._
 import com.advancedtelematic.libats.data.RefinedUtils._
+import com.advancedtelematic.libats.http.HttpCodecs._
 import com.advancedtelematic.libats.messaging_datatype.DataType.{EcuSerial, ValidEcuSerial}
 import com.advancedtelematic.libats.messaging_datatype.MessageCodecs._
-import com.advancedtelematic.libtuf.data.RefinedStringEncoding._
-import com.advancedtelematic.libtuf.data.TufCodecs.{uriDecoder, uriEncoder, _}
+import com.advancedtelematic.libtuf.data.ClientCodecs._
+import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json, JsonObject}

--- a/src/main/scala/com/advancedtelematic/director/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/DataType.scala
@@ -3,8 +3,8 @@ package com.advancedtelematic.director.data
 import akka.http.scaladsl.model.Uri
 import com.advancedtelematic.director.data.FileCacheRequestStatus.FileCacheRequestStatus
 import com.advancedtelematic.libats.codecs.CirceEnum
-import com.advancedtelematic.libats.data.Namespace
-import com.advancedtelematic.libats.messaging_datatype.DataType.{Checksum, EcuSerial, DeviceId, HashMethod, TargetFilename, UpdateId, ValidChecksum}
+import com.advancedtelematic.libats.data.DataType.{Checksum, HashMethod, Namespace, ValidChecksum}
+import com.advancedtelematic.libats.messaging_datatype.DataType.{EcuSerial, DeviceId, TargetFilename, UpdateId}
 import com.advancedtelematic.libtuf.data.ClientDataType.ClientHashes
 import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, RepoId, RoleType, TargetName, TufKey}
 import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat.TargetFormat

--- a/src/main/scala/com/advancedtelematic/director/data/Messages.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/Messages.scala
@@ -1,19 +1,19 @@
 package com.advancedtelematic.director.data
 
+import com.advancedtelematic.director.data.MessageDataType.UpdateStatus
 import com.advancedtelematic.director.data.MessageDataType.UpdateStatus.UpdateStatus
 import com.advancedtelematic.director.data.MessageDataType.SOTA_Instant
 import com.advancedtelematic.director.data.Messages.UpdateSpec
-import com.advancedtelematic.libats.codecs.Codecs._
-import com.advancedtelematic.libats.codecs.CirceEnum
-import com.advancedtelematic.libats.data.Namespace
-import com.advancedtelematic.libats.messaging.Messages.MessageLike
+import com.advancedtelematic.libats.codecs.CirceCodecs._
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.messaging_datatype.MessageLike
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
 import java.time.Instant
 import java.util.UUID
 
 object MessageDataType {
 
-  object UpdateStatus extends CirceEnum {
+  object UpdateStatus extends Enumeration {
     type UpdateStatus = Value
 
     val Pending, InFlight, Canceled, Failed, Finished = Value
@@ -30,6 +30,9 @@ object MessageCodecs {
   import io.circe.{Decoder, DecodingFailure, Encoder, Json}
   import io.circe.generic.semiauto._
   import java.time.format.{DateTimeFormatter, DateTimeParseException}
+
+  implicit val updateStatusEncoder: Encoder[UpdateStatus] = Encoder.enumEncoder(UpdateStatus)
+  implicit val updateStatusDecoder: Decoder[UpdateStatus] = Decoder.enumDecoder(UpdateStatus)
 
   implicit val dateTimeEncoder : Encoder[SOTA_Instant] =
     Encoder.instance[SOTA_Instant]( x =>  Json.fromString( x.inner.toString) )

--- a/src/main/scala/com/advancedtelematic/director/db/CancelUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/CancelUpdate.scala
@@ -1,7 +1,7 @@
 package com.advancedtelematic.director.db
 
 import akka.http.scaladsl.util.FastFuture
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/main/scala/com/advancedtelematic/director/db/DeviceUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/DeviceUpdate.scala
@@ -2,9 +2,8 @@ package com.advancedtelematic.director.db
 
 import com.advancedtelematic.director.data.DataType.Image
 import com.advancedtelematic.director.data.DeviceRequest.EcuManifest
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, UpdateId}
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.MySQLProfile.api._
@@ -23,8 +22,6 @@ object DeviceUpdate extends AdminRepositorySupport
     with DeviceRepositorySupport
     with FileCacheRequestRepositorySupport {
   import DeviceUpdateResult._
-
-  private lazy val _log = LoggerFactory.getLogger(this.getClass)
 
   def subMap[K, V](xs: Map[K,V], ys: Map[K,V]): Boolean = xs.forall {
     case (k,v) => ys.get(k).contains(v)

--- a/src/main/scala/com/advancedtelematic/director/db/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Errors.scala
@@ -3,9 +3,9 @@ package com.advancedtelematic.director.db
 import akka.http.scaladsl.model.StatusCodes
 import com.advancedtelematic.director.data.DataType._
 import com.advancedtelematic.director.data.UpdateType.UpdateType
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.data.ErrorCode
 import com.advancedtelematic.libats.http.Errors.{EntityAlreadyExists, MissingEntity, RawError}
-import com.advancedtelematic.libats.http.ErrorCode
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 
 object ErrorCodes {

--- a/src/main/scala/com/advancedtelematic/director/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Repository.scala
@@ -5,15 +5,16 @@ import com.advancedtelematic.director.data.FileCacheRequestStatus
 import com.advancedtelematic.director.data.DataType
 import com.advancedtelematic.director.data.UpdateType.UpdateType
 import com.advancedtelematic.director.db.Mappers._
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.{Checksum, Namespace}
 import com.advancedtelematic.libats.data.PaginationResult
-import com.advancedtelematic.libats.messaging_datatype.DataType.{Checksum, DeviceId, EcuSerial, TargetFilename, UpdateId}
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, TargetFilename, UpdateId}
 import com.advancedtelematic.libats.slick.codecs.SlickRefined._
 import com.advancedtelematic.libats.slick.db.SlickAnyVal._
 import com.advancedtelematic.libats.slick.db.SlickExtensions._
 import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
 import com.advancedtelematic.libtuf.crypt.TufCrypto
 import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, RepoId, RoleType, TufKey}
+import com.advancedtelematic.libtuf_server.data.TufSlickMappings._
 import io.circe.Json
 import java.time.Instant
 

--- a/src/main/scala/com/advancedtelematic/director/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Schema.scala
@@ -7,9 +7,9 @@ import cats.implicits._
 import com.advancedtelematic.director.data.DataType._
 import com.advancedtelematic.director.data.{LaunchedMultiTargetUpdateStatus, UpdateType}
 import com.advancedtelematic.director.data.FileCacheRequestStatus.FileCacheRequestStatus
-import com.advancedtelematic.libats.data.Namespace
-import com.advancedtelematic.libats.messaging_datatype.DataType.{Checksum, DeviceId, EcuSerial, HashMethod, TargetFilename, UpdateId, ValidChecksum}
-import com.advancedtelematic.libats.messaging_datatype.DataType.HashMethod.HashMethod
+import com.advancedtelematic.libats.data.DataType.{Checksum, HashMethod, Namespace, ValidChecksum}
+import com.advancedtelematic.libats.data.DataType.HashMethod.HashMethod
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, TargetFilename, UpdateId}
 import com.advancedtelematic.libtuf.crypt.TufCrypto
 import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, KeyType, RepoId, TargetName, TufKey}
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
@@ -20,12 +20,9 @@ import java.time.Instant
 import slick.jdbc.MySQLProfile.api._
 
 object Mappers {
-  import com.advancedtelematic.libats.messaging_datatype.MessageCodecs.{checksumDecoder, checksumEncoder}
-  import com.advancedtelematic.libats.slick.db.SlickCirceMapper
+  import com.advancedtelematic.libats.slick.codecs.SlickEnumMapper
   import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat
-  import com.advancedtelematic.libtuf_server.data.SlickEnumMapper
 
-  implicit val checkSumMapper = SlickCirceMapper.circeMapper[Checksum]
   implicit val hashMethodColumn = MappedColumnType.base[HashMethod, String](_.toString, HashMethod.withName)
   implicit val targetFormatMapper = SlickEnumMapper.enumMapper(TargetFormat)
 }

--- a/src/main/scala/com/advancedtelematic/director/db/SetMultiTargets.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/SetMultiTargets.scala
@@ -7,7 +7,7 @@ import com.advancedtelematic.director.data.LaunchedMultiTargetUpdateStatus
 import com.advancedtelematic.director.data.Messages.UpdateSpec
 import com.advancedtelematic.director.data.MessageDataType.UpdateStatus
 import com.advancedtelematic.director.data.UpdateType
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, UpdateId}
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/main/scala/com/advancedtelematic/director/db/SetTargets.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/SetTargets.scala
@@ -3,7 +3,7 @@ package com.advancedtelematic.director.db
 import com.advancedtelematic.director.data.AdminRequest.SetTarget
 import com.advancedtelematic.director.data.DataType.CustomImage
 import com.advancedtelematic.director.data.UpdateType
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, UpdateId}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/main/scala/com/advancedtelematic/director/http/AdminResource.scala
+++ b/src/main/scala/com/advancedtelematic/director/http/AdminResource.scala
@@ -16,15 +16,15 @@ import com.advancedtelematic.director.db.{AdminRepositorySupport, AutoUpdateRepo
   SetMultiTargets, SetTargets}
 import com.advancedtelematic.director.repo.DirectorRepo
 import com.advancedtelematic.libats.codecs.AkkaCirce._
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.data.RefinedUtils._
+import com.advancedtelematic.libats.http.UUIDKeyPath._
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, UpdateId, ValidEcuSerial}
-import com.advancedtelematic.libtuf.keyserver.KeyserverClient
 import com.advancedtelematic.libtuf.data.ClientCodecs._
-import com.advancedtelematic.libtuf.data.RefinedStringEncoding._
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.TargetName
+import com.advancedtelematic.libtuf_server.keyserver.KeyserverClient
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.MySQLProfile.api._

--- a/src/main/scala/com/advancedtelematic/director/http/DeviceResource.scala
+++ b/src/main/scala/com/advancedtelematic/director/http/DeviceResource.scala
@@ -8,17 +8,18 @@ import com.advancedtelematic.director.db.{DeviceRepositorySupport, FileCacheRepo
 import com.advancedtelematic.director.manifest.Verifier.Verifier
 import com.advancedtelematic.director.manifest.{AfterDeviceManifestUpdate, DeviceManifestUpdate}
 import com.advancedtelematic.director.roles.Roles
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.http.UUIDKeyPath._
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceSeen
 import com.advancedtelematic.libtuf.data.ClientCodecs._
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.{RoleType, SignedPayload, TufKey}
-import com.advancedtelematic.libtuf.keyserver.KeyserverClient
+import com.advancedtelematic.libtuf_server.data.Marshalling.JsonRoleTypeMetaPath
+import com.advancedtelematic.libtuf_server.keyserver.KeyserverClient
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe.Json
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.ExecutionContext
 import slick.jdbc.MySQLProfile.api._
@@ -34,8 +35,6 @@ class DeviceResource(extractNamespace: Directive1[Namespace],
     with RepoNameRepositorySupport {
   import akka.http.scaladsl.server.Directives._
   import akka.http.scaladsl.server.Route
-
-  private lazy val _log = LoggerFactory.getLogger(this.getClass)
 
   private val afterUpdate = new AfterDeviceManifestUpdate(coreClient)
   private val deviceManifestUpdate = new DeviceManifestUpdate(afterUpdate, verifier)
@@ -77,7 +76,7 @@ class DeviceResource(extractNamespace: Directive1[Namespace],
         }
       } ~
       get {
-        (path(RoleType.JsonRoleTypeMetaPath) & logDevice(ns, device)) {
+        (path(JsonRoleTypeMetaPath) & logDevice(ns, device)) {
           case RoleType.ROOT => fetchRoot(ns)
           case RoleType.TARGETS =>
             val f = roles.fetchTargets(ns, device)

--- a/src/main/scala/com/advancedtelematic/director/http/DirectorRoutes.scala
+++ b/src/main/scala/com/advancedtelematic/director/http/DirectorRoutes.scala
@@ -11,7 +11,7 @@ import com.advancedtelematic.libats.http.ErrorHandler
 import com.advancedtelematic.libats.http.DefaultRejectionHandler.rejectionHandler
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
 import com.advancedtelematic.libtuf.data.TufDataType.TufKey
-import com.advancedtelematic.libtuf.keyserver.KeyserverClient
+import com.advancedtelematic.libtuf_server.keyserver.KeyserverClient
 import slick.jdbc.MySQLProfile.api._
 
 import scala.concurrent.ExecutionContext

--- a/src/main/scala/com/advancedtelematic/director/http/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/director/http/Errors.scala
@@ -1,8 +1,8 @@
 package com.advancedtelematic.director.http
 
 import akka.http.scaladsl.model.StatusCodes
+import com.advancedtelematic.libats.data.ErrorCode
 import com.advancedtelematic.libats.http.Errors.RawError
-import com.advancedtelematic.libats.http.ErrorCode
 
 object ErrorCodes {
   val TargetsNotSubSetOfDevice = ErrorCode("targets_not_subset_of_device")

--- a/src/main/scala/com/advancedtelematic/director/http/MultiTargetUpdatesResource.scala
+++ b/src/main/scala/com/advancedtelematic/director/http/MultiTargetUpdatesResource.scala
@@ -6,9 +6,10 @@ import akka.http.scaladsl.server._
 import com.advancedtelematic.director.data.Codecs._
 import com.advancedtelematic.director.data.DataType.MultiTargetUpdateRequest
 import com.advancedtelematic.director.db.MultiTargetUpdatesRepositorySupport
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.codecs.CirceRefined._
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.http.UUIDKeyPath._
 import com.advancedtelematic.libats.messaging_datatype.DataType.UpdateId
-import com.advancedtelematic.libtuf.data.RefinedStringEncoding._
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import slick.jdbc.MySQLProfile.api.Database
 

--- a/src/main/scala/com/advancedtelematic/director/http/NamespaceDirectives.scala
+++ b/src/main/scala/com/advancedtelematic/director/http/NamespaceDirectives.scala
@@ -1,7 +1,7 @@
 package com.advancedtelematic.director.http
 
 import akka.http.scaladsl.server.Directive1
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.util.Try

--- a/src/main/scala/com/advancedtelematic/director/manifest/AfterUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/AfterUpdate.scala
@@ -9,7 +9,7 @@ import com.advancedtelematic.director.data.MessageDataType.UpdateStatus
 import com.advancedtelematic.director.data.{LaunchedMultiTargetUpdateStatus, UpdateType}
 import com.advancedtelematic.director.db.{AdminRepositorySupport, DeviceUpdate,
   LaunchedMultiTargetUpdateRepositorySupport, UpdateTypesRepositorySupport}
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, UpdateId, OperationResult}
 import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceUpdateReport

--- a/src/main/scala/com/advancedtelematic/director/manifest/DeviceManifestUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/DeviceManifestUpdate.scala
@@ -5,7 +5,7 @@ import com.advancedtelematic.director.data.Codecs._
 import com.advancedtelematic.director.data.DeviceRequest.{CustomManifest, EcuManifest}
 import com.advancedtelematic.director.db.{DeviceRepositorySupport, DeviceUpdate, DeviceUpdateResult, UpdateTypesRepositorySupport}
 import com.advancedtelematic.director.manifest.Verifier.Verifier
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, OperationResult}
 import com.advancedtelematic.libtuf.data.TufDataType.{SignedPayload, TufKey}
 import io.circe.Json

--- a/src/main/scala/com/advancedtelematic/director/manifest/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/Errors.scala
@@ -2,8 +2,8 @@ package com.advancedtelematic.director.manifest
 
 import akka.http.scaladsl.model.StatusCodes
 import com.advancedtelematic.director.data.DataType.Ecu
+import com.advancedtelematic.libats.data.ErrorCode
 import com.advancedtelematic.libats.http.Errors.{MissingEntity, RawError}
-import com.advancedtelematic.libats.http.ErrorCode
 
 object ErrorCodes {
   val EcuNotPrimary = ErrorCode("ecu_not_primary")

--- a/src/main/scala/com/advancedtelematic/director/manifest/SignatureVerification.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/SignatureVerification.scala
@@ -2,7 +2,7 @@ package com.advancedtelematic.director.manifest
 
 import com.advancedtelematic.libtuf.data.TufDataType.{Signature, TufKey}
 import com.advancedtelematic.libtuf.crypt.TufCrypto
-import com.advancedtelematic.libtuf.crypt.Sha256Digest
+import com.advancedtelematic.libtuf_server.crypto.Sha256Digest
 import java.security.SignatureException
 import org.slf4j.LoggerFactory
 

--- a/src/main/scala/com/advancedtelematic/director/manifest/Verify.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/Verify.scala
@@ -5,9 +5,9 @@ import com.advancedtelematic.director.data.DeviceRequest.{DeviceManifest, EcuMan
 import com.advancedtelematic.director.data.Codecs._
 import com.advancedtelematic.libats.messaging_datatype.DataType.EcuSerial
 import com.advancedtelematic.libtuf.crypt.CanonicalJson._
-import com.advancedtelematic.libtuf.crypt.Sha256Digest
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.{ClientSignature, Signature, SignedPayload, TufKey}
+import com.advancedtelematic.libtuf_server.crypto.Sha256Digest
 import io.circe.{Encoder, Json}
 import io.circe.syntax._
 import org.slf4j.LoggerFactory

--- a/src/main/scala/com/advancedtelematic/director/migration/AutoInstall.scala
+++ b/src/main/scala/com/advancedtelematic/director/migration/AutoInstall.scala
@@ -17,10 +17,10 @@ import akka.stream.scaladsl.{Flow, Sink, Source}
 import cats.syntax.show._
 import com.advancedtelematic.director.Settings
 import com.advancedtelematic.director.db.{AdminRepositorySupport, AutoUpdateRepositorySupport, Errors => DBErrors, RepoNameRepositorySupport}
-import com.advancedtelematic.libats.data.{Namespace, PaginationResult}
+import com.advancedtelematic.libats.data.{ErrorCode, PaginationResult}
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial}
 import com.advancedtelematic.libats.http.BootApp
-import com.advancedtelematic.libats.http.ErrorCode
 import com.advancedtelematic.libats.http.Errors.RawError
 import com.advancedtelematic.libats.slick.db.DatabaseConfig
 import com.advancedtelematic.libtuf.data.ClientCodecs._

--- a/src/main/scala/com/advancedtelematic/director/repo/DirectorRepo.scala
+++ b/src/main/scala/com/advancedtelematic/director/repo/DirectorRepo.scala
@@ -2,9 +2,9 @@ package com.advancedtelematic.director.repo
 
 import com.advancedtelematic.director.db.RepoNameRepositorySupport
 import com.advancedtelematic.director.db.Errors.MissingNamespaceRepo
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libtuf.data.TufDataType.RepoId
-import com.advancedtelematic.libtuf.keyserver.KeyserverClient
+import com.advancedtelematic.libtuf_server.keyserver.KeyserverClient
 
 import scala.concurrent.{ExecutionContext, Future}
 import slick.driver.MySQLDriver.api.Database

--- a/src/main/scala/com/advancedtelematic/director/roles/Roles.scala
+++ b/src/main/scala/com/advancedtelematic/director/roles/Roles.scala
@@ -7,7 +7,7 @@ import com.advancedtelematic.director.data.FileCacheRequestStatus
 import com.advancedtelematic.director.db.{AdminRepositorySupport, DeviceRepositorySupport, Errors => DBErrors,
   FileCacheRepositorySupport, FileCacheRequestRepositorySupport, MultiTargetUpdatesRepositorySupport}
 import com.advancedtelematic.director.roles.RolesGeneration.MtuDiffDataMissing
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import io.circe.Json
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/test/scala/com/advancedtelematic/diff_service/client/FakeDiffServiceClient.scala
+++ b/src/test/scala/com/advancedtelematic/diff_service/client/FakeDiffServiceClient.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.Uri
 import com.advancedtelematic.diff_service.data.DataType.CreateDiffInfoRequest
 import com.advancedtelematic.director.data.DataType.{DiffInfo, TargetUpdate}
 import com.advancedtelematic.director.util.NamespaceTag.NamespaceTag
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.{BsDiffRequestId, DeltaRequestId}
 import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat._
 

--- a/src/test/scala/com/advancedtelematic/diff_service/data/Conversions.scala
+++ b/src/test/scala/com/advancedtelematic/diff_service/data/Conversions.scala
@@ -2,8 +2,9 @@ package com.advancedtelematic.diff_service.data
 
 import com.advancedtelematic.diff_service.client.DiffServiceDirectorClient
 import com.advancedtelematic.diff_service.util.DiffServiceSpec
+import com.advancedtelematic.libats.data.DataType.{Checksum, HashMethod, ValidChecksum}
 import com.advancedtelematic.libats.data.RefinedUtils._
-import com.advancedtelematic.libats.messaging_datatype.DataType.{Checksum, HashMethod, ValidCommit, ValidChecksum}
+import com.advancedtelematic.libats.messaging_datatype.DataType.ValidCommit
 
 class ConversionsSpec extends DiffServiceSpec {
 

--- a/src/test/scala/com/advancedtelematic/diff_service/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/diff_service/data/Generators.scala
@@ -2,7 +2,8 @@ package com.advancedtelematic.diff_service.data
 
 import com.advancedtelematic.diff_service.data.DataType._
 import com.advancedtelematic.director.data.DataType.TargetUpdate
-import com.advancedtelematic.libats.messaging_datatype.DataType.{Checksum, HashMethod, ValidChecksum, ValidTargetFilename}
+import com.advancedtelematic.libats.data.DataType.{Checksum, HashMethod, ValidChecksum}
+import com.advancedtelematic.libats.messaging_datatype.DataType.ValidTargetFilename
 import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat._
 import eu.timepit.refined.api.Refined
 import org.scalacheck.Gen

--- a/src/test/scala/com/advancedtelematic/diff_service/http/DiffResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/diff_service/http/DiffResourceSpec.scala
@@ -10,6 +10,7 @@ import com.advancedtelematic.director.util.NamespaceTag.Namespaced
 import com.advancedtelematic.libats.messaging_datatype.Messages.{GeneratedBsDiff, GeneratedDelta}
 import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat.{BINARY, OSTREE}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import java.net.URI
 
 class DiffResourceSpec extends DiffServiceSpec
     with DefaultPatience
@@ -38,7 +39,7 @@ class DiffResourceSpec extends DiffServiceSpec
     val size = 22
     val checksum = GenChecksum.sample.get
 
-    val generatedDelta = GeneratedDelta(id, ns.get, fromCommit, toCommit, resultUri, size, checksum)
+    val generatedDelta = GeneratedDelta(id, ns.get, fromCommit, toCommit, URI.create(resultUri.toString), size, checksum)
     diffListener.generatedDeltaAction(generatedDelta).futureValue
 
     Get(apiUri("diffs/static_delta"), query).namespaced ~> routes ~> check {
@@ -80,7 +81,7 @@ class DiffResourceSpec extends DiffServiceSpec
     val size = 22
     val checksum = GenChecksum.sample.get
 
-    val generatedBsDiff = GeneratedBsDiff(id, ns.get, fromUri, toUri, resultUri, size, checksum)
+    val generatedBsDiff = GeneratedBsDiff(id, ns.get, URI.create(fromUri.toString), URI.create(toUri.toString), URI.create(resultUri.toString), size, checksum)
     diffListener.generatedBsDiffAction(generatedBsDiff).futureValue
 
     Get(apiUri("diffs/bs_diff"), query).namespaced ~> routes ~> check {

--- a/src/test/scala/com/advancedtelematic/diff_service/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/diff_service/util/ResourceSpec.scala
@@ -8,7 +8,7 @@ import com.advancedtelematic.diff_service.client.DiffServiceDirectorClient
 import com.advancedtelematic.diff_service.daemon.DiffListener
 import com.advancedtelematic.diff_service.http.DiffResource
 import com.advancedtelematic.director.Settings
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.http.DefaultRejectionHandler.rejectionHandler
 import com.advancedtelematic.libats.http.ErrorHandler
 import com.advancedtelematic.libats.messaging.MessageBusPublisher

--- a/src/test/scala/com/advancedtelematic/director/client/FakeCoreClient.scala
+++ b/src/test/scala/com/advancedtelematic/director/client/FakeCoreClient.scala
@@ -2,7 +2,7 @@ package com.advancedtelematic.director.client
 
 import akka.http.scaladsl.util.FastFuture
 import com.advancedtelematic.director.data.DeviceRequest.OperationResult
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
 import java.util.concurrent.ConcurrentHashMap
 import scala.concurrent.Future

--- a/src/test/scala/com/advancedtelematic/director/client/FakeKeyserverClient.scala
+++ b/src/test/scala/com/advancedtelematic/director/client/FakeKeyserverClient.scala
@@ -8,7 +8,7 @@ import com.advancedtelematic.libtuf.data.ClientDataType.{RoleKeys, RootRole}
 import com.advancedtelematic.libtuf.data.ClientCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType._
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
-import com.advancedtelematic.libtuf.keyserver.KeyserverClient
+import com.advancedtelematic.libtuf_server.keyserver.KeyserverClient
 import io.circe.{Decoder, Encoder, Json}
 import io.circe.syntax._
 import java.security.{KeyPair, PublicKey}

--- a/src/test/scala/com/advancedtelematic/director/data/CodecsSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/CodecsSpec.scala
@@ -6,9 +6,9 @@ import com.advancedtelematic.director.data.DataType.{FileInfo, Hashes, Image, Ta
 import com.advancedtelematic.director.data.DeviceRequest.{CustomManifest, DeviceManifest, DeviceRegistration, EcuManifest, OperationResult}
 import com.advancedtelematic.director.data.TestCodecs._
 import com.advancedtelematic.director.util.DirectorSpec
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.{Checksum, HashMethod, Namespace, ValidChecksum}
 import com.advancedtelematic.libats.data.RefinedUtils._
-import com.advancedtelematic.libats.messaging_datatype.DataType.{Checksum, DeviceId, EcuSerial, HashMethod, UpdateId, ValidChecksum, ValidEcuSerial}
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, UpdateId, ValidEcuSerial}
 import com.advancedtelematic.libtuf.crypt.TufCrypto
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.{
@@ -64,12 +64,12 @@ class CodecsSpec extends DirectorSpec {
   }
 
   {
-    val ecu_manifest_sample: String = """{"signatures": [{"method": "rsassa-pss", "sig": "df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804", "keyid": "49309f114b857e4b29bfbff1c1c75df59f154fbc45539b2eb30c8a867843b2cb"}], "signed": {"timeserver_time": "2016-10-14T16:06:03Z", "installed_image": {"filepath": "/file2.txt", "fileinfo": {"hashes": {"sha256": "3910b632b105b1e03baa9780fc719db106f2040ebfe473c66710c7addbb2605a"}, "length": 21}}, "previous_timeserver_time": "2016-10-14T16:06:03Z", "ecu_serial": "ecu11111", "attacks_detected": ""}}"""
+    val ecu_manifest_sample: String = """{"signatures": [{"method": "rsassa-pss-sha256", "sig": "df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804", "keyid": "49309f114b857e4b29bfbff1c1c75df59f154fbc45539b2eb30c8a867843b2cb"}], "signed": {"timeserver_time": "2016-10-14T16:06:03Z", "installed_image": {"filepath": "/file2.txt", "fileinfo": {"hashes": {"sha256": "3910b632b105b1e03baa9780fc719db106f2040ebfe473c66710c7addbb2605a"}, "length": 21}}, "previous_timeserver_time": "2016-10-14T16:06:03Z", "ecu_serial": "ecu11111", "attacks_detected": ""}}"""
 
     val ecu_manifest_sample_parsed: SignedPayload[EcuManifest]
       = SignedPayload(
         signatures = Vector(ClientSignature(
-                              method = SignatureMethod.RSASSA_PSS,
+                              method = SignatureMethod.RSASSA_PSS_SHA256,
                               sig = "df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804".refineTry[ValidSignature].get,
                               keyid = "49309f114b857e4b29bfbff1c1c75df59f154fbc45539b2eb30c8a867843b2cb".refineTry[ValidKeyId].get)),
         signed = EcuManifest(timeserver_time = Instant.ofEpochSecond(1476461163),
@@ -195,13 +195,13 @@ class CodecsSpec extends DirectorSpec {
     example(sample, parsed, "UpdateSpec creates zero uuid for packageUuid")
   }
   {
-    def wrapSample(inner: String): String = s"""{"signatures": [{"method": "rsassa-pss", "sig": "df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804", "keyid": "49309f114b857e4b29bfbff1c1c75df59f154fbc45539b2eb30c8a867843b2cb"}], "signed": $inner}"""
+    def wrapSample(inner: String): String = s"""{"signatures": [{"method": "rsassa-pss-sha256", "sig": "df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804", "keyid": "49309f114b857e4b29bfbff1c1c75df59f154fbc45539b2eb30c8a867843b2cb"}], "signed": $inner}"""
 
     val ecu_manifest_sample: String = wrapSample("""{"timeserver_time": "2016-10-14T16:06:03Z", "installed_image": {"filepath": "/file2.txt", "fileinfo": {"hashes": {"sha256": "3910b632b105b1e03baa9780fc719db106f2040ebfe473c66710c7addbb2605a"}, "length": 21}}, "previous_timeserver_time": "2016-10-14T16:06:03Z", "ecu_serial": "ecu11111", "attacks_detected": ""}""")
 
     def wrapSigned[T : Encoder](t: T): SignedPayload[T] =
       SignedPayload(signatures = Vector(ClientSignature(
-                              method = SignatureMethod.RSASSA_PSS,
+                              method = SignatureMethod.RSASSA_PSS_SHA256,
                               sig = "df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804df043006d4322a386cf85a6761a96bb8c92b2a41f4a4201badb8aae6f6dc17ef930addfa96a3d17f20533a01c158a7a33e406dd8291382a1bbab772bd2fa9804".refineTry[ValidSignature].get,
                               keyid = "49309f114b857e4b29bfbff1c1c75df59f154fbc45539b2eb30c8a867843b2cb".refineTry[ValidKeyId].get)),
 

--- a/src/test/scala/com/advancedtelematic/director/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/Generators.scala
@@ -8,10 +8,11 @@ import com.advancedtelematic.director.data.DeviceRequest._
 import com.advancedtelematic.director.data.GeneratorOps._
 import com.advancedtelematic.director.data.Legacy._
 import com.advancedtelematic.director.data.TestCodecs._
-import com.advancedtelematic.libats.messaging_datatype.DataType.{Checksum, EcuSerial, HashMethod, ValidChecksum, ValidTargetFilename}
+import com.advancedtelematic.libats.data.DataType.{Checksum, HashMethod, ValidChecksum}
+import com.advancedtelematic.libats.messaging_datatype.DataType.{EcuSerial, ValidTargetFilename}
 import com.advancedtelematic.libtuf.crypt.TufCrypto
 import com.advancedtelematic.libtuf.data.TufCodecs._
-import com.advancedtelematic.libtuf.data.TufDataType.{Checksum => _, _}
+import com.advancedtelematic.libtuf.data.TufDataType._
 import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat._
 import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat.{BINARY, OSTREE, TargetFormat}
 import io.circe.Encoder
@@ -33,7 +34,7 @@ trait Generators {
     = Gen.const(RsaKeyType)
 
   lazy val GenSignatureMethod: Gen[SignatureMethod]
-    = Gen.const(SignatureMethod.RSASSA_PSS)
+    = Gen.const(SignatureMethod.RSASSA_PSS_SHA256)
 
   lazy val GenTufKey: Gen[TufKey] = for {
     keyType <- GenKeyType

--- a/src/test/scala/com/advancedtelematic/director/data/TestCodecs.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/TestCodecs.scala
@@ -3,8 +3,7 @@ package com.advancedtelematic.director.data
 import com.advancedtelematic.director.data.Codecs._
 import com.advancedtelematic.director.data.DeviceRequest.DeviceManifest
 import com.advancedtelematic.director.data.Legacy.LegacyDeviceManifest
-import com.advancedtelematic.libats.codecs.AkkaCirce._
-import com.advancedtelematic.libtuf.data.RefinedStringEncoding._
+import com.advancedtelematic.libats.codecs.CirceCodecs._
 import com.advancedtelematic.libtuf.data.TufCodecs._
 
 import io.circe.{Decoder, Encoder}

--- a/src/test/scala/com/advancedtelematic/director/http/DiffSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/DiffSpec.scala
@@ -8,8 +8,9 @@ import com.advancedtelematic.director.data.GeneratorOps._
 import com.advancedtelematic.director.db.{FileCacheRequestRepositorySupport, RepoNameRepositorySupport}
 import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, ResourceSpec}
 import com.advancedtelematic.director.util.NamespaceTag._
+import com.advancedtelematic.libats.data.RefinedUtils._
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
-import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, RepoId}
+import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, RepoId, ValidTargetFilename}
 import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat.OSTREE
 import eu.timepit.refined.api.Refined
 import scala.concurrent.Future
@@ -92,6 +93,6 @@ class DiffSpec extends DirectorSpec
     timestamp.signed.version shouldBe 1
 
     val targets = fetchTargetsFor(device)
-    targets.signed.targets(bto.target).custom.get.as[TargetCustom].right.get.diff.get shouldBe diffInfo
+    targets.signed.targets(bto.target.get.refineTry[ValidTargetFilename].get).custom.get.as[TargetCustom].right.get.diff.get shouldBe diffInfo
   }
 }

--- a/src/test/scala/com/advancedtelematic/director/http/NamespacedRequests.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/NamespacedRequests.scala
@@ -10,13 +10,12 @@ import com.advancedtelematic.director.data.Legacy.LegacyDeviceManifest
 import com.advancedtelematic.director.data.TestCodecs._
 import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, ResourceSpec}
 import com.advancedtelematic.director.util.NamespaceTag._
-import com.advancedtelematic.libats.codecs.AkkaCirce._
+import com.advancedtelematic.libats.codecs.CirceCodecs._
 import com.advancedtelematic.libats.data.PaginationResult
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, TargetFilename, UpdateId}
 import com.advancedtelematic.libtuf.data.ClientDataType.{RootRole, TargetsRole, TimestampRole}
 import com.advancedtelematic.libtuf.data.ClientCodecs._
 import com.advancedtelematic.libtuf.data.TufCodecs._
-import com.advancedtelematic.libtuf.data.RefinedStringEncoding._
 import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, RepoId, SignedPayload, TargetName, TufKey}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe.Json

--- a/src/test/scala/com/advancedtelematic/director/http/RegisterNamespaceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/RegisterNamespaceSpec.scala
@@ -4,7 +4,7 @@ import com.advancedtelematic.director.daemon.CreateRepoWorker
 import com.advancedtelematic.director.db.RepoNameRepositorySupport
 import com.advancedtelematic.director.repo.DirectorRepo
 import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, ResourceSpec}
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.Messages.UserCreated
 import com.advancedtelematic.libats.test.DatabaseSpec
 import com.advancedtelematic.libtuf.data.TufDataType.RepoId

--- a/src/test/scala/com/advancedtelematic/director/http/Requests.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/Requests.scala
@@ -12,7 +12,6 @@ import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, Resou
 import com.advancedtelematic.director.util.NamespaceTag._
 import com.advancedtelematic.libats.codecs.AkkaCirce._
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial, UpdateId}
-import com.advancedtelematic.libtuf.data.RefinedStringEncoding._
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, SignedPayload}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._

--- a/src/test/scala/com/advancedtelematic/director/manifest/VerifySpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/manifest/VerifySpec.scala
@@ -10,7 +10,7 @@ import com.advancedtelematic.director.data.GeneratorOps._
 import com.advancedtelematic.director.data.Legacy.LegacyDeviceManifest
 import com.advancedtelematic.director.data.TestCodecs._
 import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec}
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial}
 import com.advancedtelematic.libtuf.crypt.CanonicalJson._
 import com.advancedtelematic.libtuf.crypt.TufCrypto

--- a/src/test/scala/com/advancedtelematic/director/repo/DirectorRepoSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/repo/DirectorRepoSpec.scala
@@ -1,11 +1,11 @@
 package com.advancedtelematic.director.repo
 
 import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, ResourceSpec}
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libtuf.data.ClientDataType.RootRole
 import com.advancedtelematic.libtuf.data.TufDataType.{KeyId, KeyType, RepoId, SignedPayload, TufKey, TufPrivateKey}
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
-import com.advancedtelematic.libtuf.keyserver.KeyserverClient
+import com.advancedtelematic.libtuf_server.keyserver.KeyserverClient
 import io.circe.{Decoder, Encoder, Json}
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/test/scala/com/advancedtelematic/director/util/NamespaceTag.scala
+++ b/src/test/scala/com/advancedtelematic/director/util/NamespaceTag.scala
@@ -3,7 +3,7 @@ package com.advancedtelematic.director.util
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.headers.RawHeader
 import com.advancedtelematic.director.data.GeneratorOps._
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import org.scalacheck.Gen
 
 object NamespaceTag {

--- a/src/test/scala/com/advancedtelematic/director/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/util/ResourceSpec.scala
@@ -8,7 +8,7 @@ import com.advancedtelematic.director.http.DirectorRoutes
 import com.advancedtelematic.director.manifest.Verifier
 import com.advancedtelematic.director.roles.{Roles, RolesGeneration}
 import com.advancedtelematic.director.util.NamespaceTag.NamespaceTag
-import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
 import com.advancedtelematic.libats.test.DatabaseSpec
 import com.advancedtelematic.libtuf.data.TufDataType.TufKey


### PR DESCRIPTION
We need to bump the version of libtuf, since when someone request `root.json` we use the keyserver client to return `root.json`. But this client will parse the response from the keyserver which failed with the recent `rsa-pss-sha256` change.