### PR TITLE
BootMigrations should be executed only in one container

### DIFF
--- a/deploy/service.json
+++ b/deploy/service.json
@@ -79,7 +79,6 @@
   },
   "env": {
     "BIND_PORT": "9001",
-    "DB_MIGRATE": "true",
     "DB_PASSWORD": "${DB_PASSWORD}",
     "DB_URL": "${DB_URL}",
     "DB_USER": "${DB_USER}",

--- a/src/main/scala/com/advancedtelematic/director/Boot.scala
+++ b/src/main/scala/com/advancedtelematic/director/Boot.scala
@@ -14,7 +14,7 @@ import com.advancedtelematic.libats.http.LogDirectives.logResponseMetrics
 import com.advancedtelematic.libats.http.VersionDirectives.versionHeaders
 import com.advancedtelematic.libats.http.monitoring.MetricsSupport
 import com.advancedtelematic.libats.messaging.MessageBus
-import com.advancedtelematic.libats.slick.db.{BootMigrations, DatabaseConfig}
+import com.advancedtelematic.libats.slick.db.DatabaseConfig
 import com.advancedtelematic.libats.slick.monitoring.{DatabaseMetrics, DbHealthResource}
 import com.advancedtelematic.libtuf_server.keyserver.KeyserverHttpClient
 import com.advancedtelematic.metrics.{AkkaHttpMetricsSink, InfluxDbMetricsReporter, InfluxDbMetricsReporterSettings, OsMetricSet}
@@ -68,7 +68,6 @@ object Boot extends BootApp
   with Settings
   with VersionInfo
   with DatabaseConfig
-  with BootMigrations
   with MetricsSupport
   with DatabaseMetrics {
 


### PR DESCRIPTION
If multiple Boot and DaemonBoot exist, migrations should run
on **one** DaemonBoot only.