### PR TITLE
Revert "Add env variable REPORT_METRICS to be able to turn off metrics"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= {
   val sotaV = "0.2.89"
   val bouncyCastleV = "1.57"
   val tufV = "0.2.0-1-g5579c30"
-  val libatsV = "0.1.1-3-g68485cf"
+  val libatsV = "0.1.0-5-g6b585f0"
   val circeConfigV = "0.0.2"
 
   Seq(


### PR DESCRIPTION
This reverts commit 7ea1efbd433a8164fbf36f55c350e6fe0345ae95
which didn't run in daemon mode because of library compatibility issues.