### PR TITLE
Revert "Use openjdk alpine docker image as base for service"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,8 @@ dockerUpdateLatest := true
 defaultLinuxInstallLocation in Docker := s"/opt/${moduleName.value}"
 
 dockerCommands := Seq(
-  Cmd("FROM", "openjdk:8-jre-alpine3.7"),
+  Cmd("FROM", "alpine:3.6"),
+  Cmd("RUN", "apk upgrade --update && apk add --update openjdk8-jre bash coreutils"),
   ExecCmd("RUN", "mkdir", "-p", s"/var/log/${moduleName.value}"),
   Cmd("ADD", "opt /opt"),
   Cmd("WORKDIR", s"/opt/${moduleName.value}"),
@@ -95,9 +96,6 @@ dockerCommands := Seq(
   Cmd("RUN", s"chown -R daemon:daemon /var/log/${moduleName.value}"),
   Cmd("USER", "daemon")
 )
-
-// generate scripts for the Alpine ash shell
-enablePlugins(AshScriptPlugin)
 
 enablePlugins(JavaAppPackaging)
 


### PR DESCRIPTION
Reverts advancedtelematic/director#115

This causes director-daemon not to run `DaemonBoot`