### PR TITLE
Bugfix/ota 572/handle manifest only once

### DIFF
--- a/src/main/resources/db/migration/V16__processed_manifests.sql
+++ b/src/main/resources/db/migration/V16__processed_manifests.sql
@@ -1,0 +1,6 @@
+CREATE TABLE processed_manifests(
+  `namespace` varchar(200) NOT NULL,
+  `device` char(36) NOT NULL,
+  `hash` char(64) NOT NULL,
+  primary key (`namespace`, `device`)
+);

--- a/src/main/scala/com/advancedtelematic/director/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/DataType.scala
@@ -114,4 +114,6 @@ object DataType {
                                              status: LaunchedMultiTargetUpdateStatus.Status)
 
   final case class AutoUpdate(namespace: Namespace, device: DeviceId, ecuSerial: EcuSerial, targetName: TargetName)
+
+  final case class ProcessedManifest(namespace: Namespace, device: DeviceId, hash: String)
 }

--- a/src/main/scala/com/advancedtelematic/director/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Repository.scala
@@ -3,7 +3,7 @@ package com.advancedtelematic.director.db
 import java.time.Instant
 
 import com.advancedtelematic.director.data.AdminRequest.EcuInfoImage
-import com.advancedtelematic.director.data.DataType.{Ecu, EcuTarget, FileCacheRequest, MultiTargetUpdateRow}
+import com.advancedtelematic.director.data.DataType._
 import com.advancedtelematic.director.data.FileCacheRequestStatus
 import com.advancedtelematic.director.data.DataType
 import com.advancedtelematic.director.data.UpdateType.UpdateType
@@ -684,4 +684,31 @@ protected class AutoUpdateRepository()(implicit db: Database, ec: ExecutionConte
       .map(_.groupBy{case (device, _, _) => device}
              .map{case (k, v) => k -> v.map{case (_, hw, tu) => (hw, tu)}})
   }
+}
+
+trait ProcessedManifestsRepositorySupport {
+  def processedManifestsRepository(implicit db: Database) = new ProcessedManifestsRepository()
+}
+
+protected class ProcessedManifestsRepository()(implicit db: Database) {
+  def contains(namespace: Namespace, device: DeviceId, hash: String): Future[Boolean] = db.run {
+    Schema.processedManifests
+      .filter(_.namespace === namespace)
+      .filter(_.device === device)
+      .filter(_.hash === hash)
+      .exists
+      .result
+  }
+
+  def add(namespace: Namespace, device: DeviceId, hash: String): Future[Int] = db.run {
+    Schema.processedManifests.insertOrUpdate(ProcessedManifest(namespace, device, hash))
+  }
+
+  def deleteAction(namespace: Namespace, device: DeviceId): DBIO[Int] =
+    Schema.processedManifests
+      .filter(_.namespace === namespace)
+      .filter(_.device === device)
+      .delete
+
+  def delete(namespace: Namespace, device: DeviceId): Future[Int] = db.run(deleteAction(namespace, device))
 }

--- a/src/main/scala/com/advancedtelematic/director/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Schema.scala
@@ -237,5 +237,17 @@ object Schema {
     override def * = (namespace, device, ecuSerial, targetName) <>
       ((AutoUpdate.apply _).tupled, AutoUpdate.unapply)
   }
+
   protected [db] val autoUpdates = TableQuery[AutoUpdates]
+
+  class ProcessedManifests(tag: Tag) extends Table[ProcessedManifest](tag, "processed_manifests") {
+    def namespace = column[Namespace]("namespace")
+    def device = column[DeviceId]("device")
+    def hash = column[String]("hash")
+    def primKey = primaryKey("namespace_device_pk", (namespace, device))
+
+    override def * = (namespace, device, hash) <> ((ProcessedManifest.apply _).tupled, ProcessedManifest.unapply)
+  }
+
+  protected[db] val processedManifests = TableQuery[ProcessedManifests]
 }

--- a/src/main/scala/com/advancedtelematic/director/manifest/AfterUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/AfterUpdate.scala
@@ -16,7 +16,7 @@ import com.advancedtelematic.libtuf_server.data.Messages.DeviceUpdateReport
 
 import scala.async.Async._
 import scala.concurrent.{ExecutionContext, Future}
-import slick.driver.MySQLDriver.api._
+import slick.jdbc.MySQLProfile.api._
 
 sealed abstract class DeviceManifestUpdateResult
 
@@ -40,7 +40,7 @@ class AfterDeviceManifestUpdate(coreClient: CoreClient)
     with LaunchedMultiTargetUpdateRepositorySupport
     with UpdateTypesRepositorySupport {
 
-  val report: DeviceManifestUpdateResult => Future[Unit] = {
+  def report(deviceManifestUpdateResult: DeviceManifestUpdateResult): Future[Unit] = deviceManifestUpdateResult match {
     case NoChange() => FastFuture.successful(Unit)
     case SuccessWithoutUpdateId() => FastFuture.successful(())
     case res:SuccessWithUpdateId =>

--- a/src/main/scala/com/advancedtelematic/director/manifest/DeviceManifestUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/DeviceManifestUpdate.scala
@@ -1,28 +1,49 @@
 package com.advancedtelematic.director.manifest
 
+import java.security.MessageDigest
+
+import akka.http.scaladsl.util.FastFuture
 import cats.syntax.show._
 import com.advancedtelematic.director.data.Codecs._
 import com.advancedtelematic.director.data.DeviceRequest.{CustomManifest, EcuManifest}
-import com.advancedtelematic.director.db.{DeviceRepositorySupport, DeviceUpdate, DeviceUpdateResult, UpdateTypesRepositorySupport}
+import com.advancedtelematic.director.db.{DeviceRepositorySupport, DeviceUpdate, DeviceUpdateResult, ProcessedManifestsRepositorySupport, UpdateTypesRepositorySupport}
 import com.advancedtelematic.director.manifest.Verifier.Verifier
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, EcuSerial}
-import com.advancedtelematic.libtuf.data.TufDataType.{JsonSignedPayload, OperationResult, SignedPayload, TufKey}
+import com.advancedtelematic.libtuf.data.TufDataType.{OperationResult, SignedPayload, TufKey}
+import com.advancedtelematic.libtuf_server.crypto.Sha256Digest
+import com.advancedtelematic.libtuf.crypt.CanonicalJson._
+
 import io.circe.Json
 import org.slf4j.LoggerFactory
 
 import scala.async.Async._
 import scala.concurrent.{ExecutionContext, Future}
-import slick.driver.MySQLDriver.api._
+import slick.jdbc.MySQLProfile.api._
 
 class DeviceManifestUpdate(afterUpdate: AfterDeviceManifestUpdate,
                            verifier: TufKey => Verifier
                           )(implicit val db: Database, val ec: ExecutionContext)
-    extends DeviceRepositorySupport
-    with UpdateTypesRepositorySupport {
+    extends DeviceRepositorySupport with UpdateTypesRepositorySupport with ProcessedManifestsRepositorySupport {
   private lazy val _log = LoggerFactory.getLogger(this.getClass)
+  val digester: MessageDigest = MessageDigest.getInstance("SHA-256")
 
-  def setDeviceManifest(namespace: Namespace, device: DeviceId, signedDevMan: SignedPayload[Json]): Future[Unit] = for {
+  def setDeviceManifest(namespace: Namespace, device: DeviceId, signedDevMan: SignedPayload[Json]): Future[Unit] = {
+    val signed = signedDevMan.signed
+    val timeless = signed.mapObject(_.remove("timeserver_time").remove("previous_timeserver_time"))
+    val digest = Sha256Digest.digest(timeless.canonical.getBytes("UTF-8")).hash.value
+
+    processedManifestsRepository.contains(namespace, device, digest).flatMap {
+      case true =>
+        FastFuture.successful(())
+      case false =>
+        processDeviceManifest(namespace, device, signedDevMan).flatMap { _ =>
+          processedManifestsRepository.add(namespace, device, digest).map(_ => ())
+        }
+    }
+  }
+
+  def processDeviceManifest(namespace: Namespace, device: DeviceId, signedDevMan: SignedPayload[Json]): Future[Unit] = for {
     ecus <- deviceRepository.findEcus(namespace, device)
     ecuImages <- Future.fromTry(Verify.deviceManifest(ecus, verifier, signedDevMan))
     _ <- ecuManifests(namespace, device, ecuImages)
@@ -41,8 +62,8 @@ class DeviceManifestUpdate(afterUpdate: AfterDeviceManifestUpdate,
         Failed(namespace, device, currentVersion, Some(operations))
       }
     }
-    await(afterUpdate.report(updateResult))
 
+    await(afterUpdate.report(updateResult))
   }
 
   private def clientReportedNoErrors(namespace: Namespace, device: DeviceId, ecuImages: Seq[EcuManifest],

--- a/src/test/scala/com/advancedtelematic/director/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/Generators.scala
@@ -66,10 +66,15 @@ trait Generators {
     fi <- GenFileInfoInvalidHash
   } yield Image(fp, fi)
 
-  lazy val GenCustomImage: Gen[CustomImage] = for {
+  // doesn't contain a diff/target format
+  lazy val GenSimpleCustomImage: Gen[CustomImage] = for {
     im <- GenImage
+  } yield CustomImage(im, Uri("http://www.example.com"), None)
+
+  lazy val GenCustomImage: Gen[CustomImage] = for {
+    ci <- GenSimpleCustomImage
     tf <- Gen.option(GenTargetFormat)
-  } yield CustomImage(im, Uri("http://www.example.com"), tf)
+  } yield ci.copy(diffFormat = tf)
 
   lazy val GenChecksum: Gen[Checksum] = for {
     hash <- GenRefinedStringByCharN[ValidChecksum](64, GenHexChar)


### PR DESCRIPTION
Created an "incoming cache" for manifests to handle the same manifest only once. It needs to be handled again when the targets change, though, since manifest error handling depends on the current target (the manifest and target.json are expected to contain the same packages).