### PR TITLE
Bugfix/ota 572/revert manifest cashing and remove broken targets only

### DIFF
--- a/src/main/resources/db/migration/V16__processed_manifests.sql
+++ b/src/main/resources/db/migration/V16__processed_manifests.sql
@@ -1,6 +1,0 @@
-CREATE TABLE processed_manifests(
-  `namespace` varchar(200) NOT NULL,
-  `device` char(36) NOT NULL,
-  `hash` char(64) NOT NULL,
-  primary key (`namespace`, `device`)
-);

--- a/src/main/scala/com/advancedtelematic/director/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/DataType.scala
@@ -113,6 +113,4 @@ object DataType {
                                              status: LaunchedMultiTargetUpdateStatus.Status)
 
   final case class AutoUpdate(namespace: Namespace, device: DeviceId, ecuSerial: EcuSerial, targetName: TargetName)
-
-  final case class ProcessedManifest(namespace: Namespace, device: DeviceId, hash: String)
 }

--- a/src/main/scala/com/advancedtelematic/director/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Repository.scala
@@ -15,11 +15,13 @@ import com.advancedtelematic.libats.slick.db.SlickAnyVal._
 import com.advancedtelematic.libats.slick.db.SlickExtensions._
 import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
 import com.advancedtelematic.libtuf.crypt.TufCrypto
-import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, RepoId, RoleType, TargetFilename, TufKey}
+import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, OperationResult, RepoId, RoleType, TargetFilename, TufKey}
 import com.advancedtelematic.libtuf_server.data.TufSlickMappings._
 import io.circe.Json
+
 import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.MySQLProfile.api._
+
 import scala.util.{Failure, Success}
 import Errors._
 
@@ -186,12 +188,35 @@ protected class AdminRepository()(implicit db: Database, ec: ExecutionContext) e
       .failIfMany
       .map(_.flatten)
 
+  // skips any targets with version > sourceVersion
   protected [db] def copyTargetsAction(namespace: Namespace, device: DeviceId, sourceVersion: Int, targetVersion: Int): DBIO[Unit] =
     Schema.ecu
       .filter(_.namespace === namespace)
       .filter(_.device === device)
       .join(Schema.ecuTargets.filter(_.version === sourceVersion)).on(_.ecuSerial === _.id)
       .map(_._2)
+      .result
+      .flatMap { ecuTargets =>
+        Schema.ecuTargets ++= ecuTargets.map(_.copy(version = targetVersion))
+      }.map(_ => ())
+
+  private def contains(map: Map[EcuSerial, TargetFilename], pair: (Rep[EcuSerial], Rep[TargetFilename])) =
+    map.map { case (key, value) =>
+      pair._1 === key && pair._2 === value
+    }.reduce(_ || _)
+
+  // skips any targets in "failed"
+  protected [db] def copyTargetsAction(namespace: Namespace, device: DeviceId, sourceVersion: Int, targetVersion: Int,
+                                       failed: Map[EcuSerial, TargetFilename]): DBIO[Unit] =
+    Schema.ecu
+      .filter(_.namespace === namespace)
+      .filter(_.device === device)
+      .join(Schema.ecuTargets.filter(_.version === sourceVersion)).on(_.ecuSerial === _.id)
+      .map(_._2)
+      // remove the failed ecuTargets
+      .filterNot { ecuTarget =>
+        contains(failed, ecuTarget.id -> ecuTarget.filepath)
+      }
       .result
       .flatMap { ecuTargets =>
         Schema.ecuTargets ++= ecuTargets.map(_.copy(version = targetVersion))

--- a/src/main/scala/com/advancedtelematic/director/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Repository.scala
@@ -3,7 +3,7 @@ package com.advancedtelematic.director.db
 import java.time.Instant
 
 import com.advancedtelematic.director.data.AdminRequest.EcuInfoImage
-import com.advancedtelematic.director.data.DataType._
+import com.advancedtelematic.director.data.DataType.{Ecu, EcuTarget, FileCacheRequest, MultiTargetUpdateRow}
 import com.advancedtelematic.director.data.FileCacheRequestStatus
 import com.advancedtelematic.director.data.DataType
 import com.advancedtelematic.director.data.UpdateType.UpdateType
@@ -683,31 +683,4 @@ protected class AutoUpdateRepository()(implicit db: Database, ec: ExecutionConte
       .map(_.groupBy{case (device, _, _) => device}
              .map{case (k, v) => k -> v.map{case (_, hw, tu) => (hw, tu)}})
   }
-}
-
-trait ProcessedManifestsRepositorySupport {
-  def processedManifestsRepository(implicit db: Database) = new ProcessedManifestsRepository()
-}
-
-protected class ProcessedManifestsRepository()(implicit db: Database) {
-  def contains(namespace: Namespace, device: DeviceId, hash: String): Future[Boolean] = db.run {
-    Schema.processedManifests
-      .filter(_.namespace === namespace)
-      .filter(_.device === device)
-      .filter(_.hash === hash)
-      .exists
-      .result
-  }
-
-  def add(namespace: Namespace, device: DeviceId, hash: String): Future[Int] = db.run {
-    Schema.processedManifests.insertOrUpdate(ProcessedManifest(namespace, device, hash))
-  }
-
-  def deleteAction(namespace: Namespace, device: DeviceId): DBIO[Int] =
-    Schema.processedManifests
-      .filter(_.namespace === namespace)
-      .filter(_.device === device)
-      .delete
-
-  def delete(namespace: Namespace, device: DeviceId): Future[Int] = db.run(deleteAction(namespace, device))
 }

--- a/src/main/scala/com/advancedtelematic/director/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Schema.scala
@@ -237,17 +237,5 @@ object Schema {
     override def * = (namespace, device, ecuSerial, targetName) <>
       ((AutoUpdate.apply _).tupled, AutoUpdate.unapply)
   }
-
   protected [db] val autoUpdates = TableQuery[AutoUpdates]
-
-  class ProcessedManifests(tag: Tag) extends Table[ProcessedManifest](tag, "processed_manifests") {
-    def namespace = column[Namespace]("namespace")
-    def device = column[DeviceId]("device")
-    def hash = column[String]("hash")
-    def primKey = primaryKey("namespace_device_pk", (namespace, device))
-
-    override def * = (namespace, device, hash) <> ((ProcessedManifest.apply _).tupled, ProcessedManifest.unapply)
-  }
-
-  protected[db] val processedManifests = TableQuery[ProcessedManifests]
 }

--- a/src/main/scala/com/advancedtelematic/director/db/SetTargets.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/SetTargets.scala
@@ -15,8 +15,7 @@ import com.advancedtelematic.director.data.FileCacheRequestStatus
 
 object SetTargets extends AdminRepositorySupport
     with FileCacheRequestRepositorySupport
-    with UpdateTypesRepositorySupport
-    with ProcessedManifestsRepositorySupport {
+    with UpdateTypesRepositorySupport {
 
   protected [db] def setDeviceTargetAction(namespace: Namespace, device: DeviceId, updateId: Option[UpdateId], targets: Map[EcuSerial, CustomImage])
                                           (implicit db: Database, ec: ExecutionContext): DBIO[Int] = for {
@@ -28,7 +27,6 @@ object SetTargets extends AdminRepositorySupport
 
   def setTargets(namespace: Namespace, devTargets: Seq[(DeviceId, SetTarget)], updateId: Option[UpdateId] = None)
                 (implicit db: Database, ec: ExecutionContext): Future[Unit] = {
-
     def devAction(device: DeviceId, targets: SetTarget): DBIO[Int] =
       setDeviceTargetAction(namespace, device, updateId, targets.updates)
 
@@ -38,15 +36,8 @@ object SetTargets extends AdminRepositorySupport
         updateTypesRepository.persistAction(updateId, UpdateType.OLD_STYLE_CAMPAIGN)
     }
 
-    val updateDeviceTargets: Seq[DBIO[Int]] = devTargets.map { case (deviceId, setTarget) =>
-      devAction(deviceId, setTarget).flatMap { _ =>
-        // deleting the incoming manifest "cache" on targets change
-        processedManifestsRepository.deleteAction(namespace, deviceId)
-      }
-    }
-
-    val dbAct = DBIO.sequence(updateDeviceTargets)
-                  .andThen(updateType)
+    val dbAct = DBIO.sequence(devTargets.map((devAction _).tupled))
+      .andThen(updateType)
 
     db.run(dbAct.transactionally)
   }

--- a/src/main/scala/com/advancedtelematic/director/manifest/AfterUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/AfterUpdate.scala
@@ -16,7 +16,7 @@ import com.advancedtelematic.libtuf_server.data.Messages.DeviceUpdateReport
 
 import scala.async.Async._
 import scala.concurrent.{ExecutionContext, Future}
-import slick.jdbc.MySQLProfile.api._
+import slick.driver.MySQLDriver.api._
 
 sealed abstract class DeviceManifestUpdateResult
 
@@ -40,7 +40,7 @@ class AfterDeviceManifestUpdate(coreClient: CoreClient)
     with LaunchedMultiTargetUpdateRepositorySupport
     with UpdateTypesRepositorySupport {
 
-  def report(deviceManifestUpdateResult: DeviceManifestUpdateResult): Future[Unit] = deviceManifestUpdateResult match {
+  val report: DeviceManifestUpdateResult => Future[Unit] = {
     case NoChange() => FastFuture.successful(Unit)
     case SuccessWithoutUpdateId() => FastFuture.successful(())
     case res:SuccessWithUpdateId =>

--- a/src/main/scala/com/advancedtelematic/director/manifest/AfterUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/AfterUpdate.scala
@@ -50,16 +50,16 @@ class AfterDeviceManifestUpdate(coreClient: CoreClient)
         case UpdateType.MULTI_TARGET_UPDATE =>
           multiTargetUpdate(res)
       }
-    case res@Failed(namespace, device, currentVersion, operations) => async {
-      val lastVersion = await(DeviceUpdate.clearTargetsFrom(namespace, device, currentVersion))
-      val updatesToCancel = await(adminRepository.getUpdatesFromTo(namespace, device, currentVersion, lastVersion))
+    case res@Failed(namespace, device, deviceVersion, operations) => async {
+      val operationResults = operations.getOrElse(Map())
+      val lastVersion = await(DeviceUpdate.clearTargetsFrom(namespace, device, deviceVersion, operationResults))
+      val updatesToCancel = await(adminRepository.getUpdatesFromTo(namespace, device, deviceVersion, lastVersion))
 
       updatesToCancel match {
         case Nil => Unit
         case (version, up) +: rest =>
-          val operationResults: Map[EcuSerial, OperationResult] = Map()
-          await(clear(namespace, device, up, version, operations.getOrElse(operationResults)))
-          await(rest.toList.traverse{case (version, up) => clear(namespace, device, up, version, operationResults)})
+          await(clear(namespace, device, up, version, operationResults))
+          await(rest.toList.traverse{case (version, up) => clear(namespace, device, up, version, Map())})
       }
     }
   }

--- a/src/test/scala/com/advancedtelematic/director/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/Generators.scala
@@ -66,15 +66,10 @@ trait Generators {
     fi <- GenFileInfoInvalidHash
   } yield Image(fp, fi)
 
-  // doesn't contain a diff/target format
-  lazy val GenSimpleCustomImage: Gen[CustomImage] = for {
-    im <- GenImage
-  } yield CustomImage(im, Uri("http://www.example.com"), None)
-
   lazy val GenCustomImage: Gen[CustomImage] = for {
-    ci <- GenSimpleCustomImage
+    im <- GenImage
     tf <- Gen.option(GenTargetFormat)
-  } yield ci.copy(diffFormat = tf)
+  } yield CustomImage(im, Uri("http://www.example.com"), tf)
 
   lazy val GenChecksum: Gen[Checksum] = for {
     hash <- GenRefinedStringByCharN[ValidChecksum](64, GenHexChar)

--- a/src/test/scala/com/advancedtelematic/director/http/DeviceResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/DeviceResourceSpec.scala
@@ -19,12 +19,13 @@ import com.advancedtelematic.director.data.{EdGenerators, KeyGenerators, RsaGene
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
 import com.advancedtelematic.libtuf.data.TufDataType.{RSATufKey, TufKey}
 import io.circe.syntax._
+import org.scalatest.Inspectors
 
 trait DeviceResourceSpec extends DirectorSpec with KeyGenerators with DefaultPatience with DeviceRepositorySupport
-    with FileCacheDB with RouteResourceSpec with NamespacedRequests {
+    with FileCacheDB with RouteResourceSpec with NamespacedRequests with Inspectors {
 
-  def schedule(device: DeviceId, targets: SetTarget, updateId: UpdateId): Unit = {
-    SetTargets.setTargets(defaultNs, Seq(device -> targets), Some(updateId)).futureValue
+  def schedule(device: DeviceId, targets: SetTarget, updateId: UpdateId)(implicit ns: NamespaceTag): Unit = {
+    SetTargets.setTargets(ns.get, Seq(device -> targets), Some(updateId)).futureValue
     pretendToGenerate().futureValue
   }
 
@@ -308,7 +309,7 @@ trait DeviceResourceSpec extends DirectorSpec with KeyGenerators with DefaultPat
     val device = DeviceId.generate()
     val primEcuReg = GenRegisterEcu.generate
     val primEcu = primEcuReg.ecu_serial
-    val ecus = List(primEcuReg)
+    val ecus = GenRegisterEcu.atMost(5).generate ++ (primEcuReg :: GenRegisterEcu.atMost(5).generate)
 
     val regDev = RegisterDevice(device, primEcu, ecus)
 

--- a/src/test/scala/com/advancedtelematic/director/http/DeviceResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/DeviceResourceSpec.scala
@@ -1,7 +1,7 @@
 package com.advancedtelematic.director.http
 
 import java.util.concurrent.ConcurrentHashMap
-import java.security.{KeyPairGenerator, MessageDigest, PublicKey}
+import java.security.{KeyPairGenerator, PublicKey}
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.Uri
@@ -10,23 +10,21 @@ import com.advancedtelematic.director.data.AdminRequest._
 import com.advancedtelematic.director.data.DataType._
 import com.advancedtelematic.director.data.DeviceRequest.{CustomManifest, OperationResult}
 import com.advancedtelematic.director.data.GeneratorOps._
-import com.advancedtelematic.director.db.{DeviceRepositorySupport, FileCacheDB, ProcessedManifestsRepositorySupport, SetTargets}
+import com.advancedtelematic.director.db.{DeviceRepositorySupport, FileCacheDB, SetTargets}
 import com.advancedtelematic.director.manifest.Verifier
 import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, RouteResourceSpec}
 import com.advancedtelematic.director.util.NamespaceTag.NamespaceTag
 import com.advancedtelematic.director.data.Codecs.{encoderCustomManifest, encoderEcuManifest}
 import com.advancedtelematic.director.data.{EdGenerators, KeyGenerators, RsaGenerators}
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
-import com.advancedtelematic.libtuf.crypt.CanonicalJson._
 import com.advancedtelematic.libtuf.data.TufDataType.{RSATufKey, TufKey}
-import com.advancedtelematic.libtuf_server.crypto.Sha256Digest
 import io.circe.syntax._
 
 trait DeviceResourceSpec extends DirectorSpec with KeyGenerators with DefaultPatience with DeviceRepositorySupport
-    with FileCacheDB with RouteResourceSpec with NamespacedRequests with ProcessedManifestsRepositorySupport {
+    with FileCacheDB with RouteResourceSpec with NamespacedRequests {
 
-  def schedule(device: DeviceId, targets: SetTarget, updateId: UpdateId)(implicit ns: NamespaceTag): Unit = {
-    SetTargets.setTargets(ns.get, Seq(device -> targets), Some(updateId)).futureValue
+  def schedule(device: DeviceId, targets: SetTarget, updateId: UpdateId): Unit = {
+    SetTargets.setTargets(defaultNs, Seq(device -> targets), Some(updateId)).futureValue
     pretendToGenerate().futureValue
   }
 
@@ -304,10 +302,7 @@ trait DeviceResourceSpec extends DirectorSpec with KeyGenerators with DefaultPat
     coreClient.getReport(updateId) shouldBe Seq(operation)
   }
 
-  testWithNamespace("Campaign update with failed result_code is reported to core but cancels remaining only once") { implicit ns =>
-    val ERROR = 4
-
-    createRepoOk(testKeyType)
+  testWithNamespace("Failed campaign update is reported to core and cancels remaining") { implicit ns =>
 
     val device = DeviceId.generate()
     val primEcuReg = GenRegisterEcu.generate
@@ -323,13 +318,13 @@ trait DeviceResourceSpec extends DirectorSpec with KeyGenerators with DefaultPat
 
     updateManifestOk(device, deviceManifest)
 
-    val targetImage = GenSimpleCustomImage.generate
+    val targetImage = GenCustomImage.generate
     val targets = SetTarget(Map(primEcu -> targetImage))
     val updateId = UpdateId.generate
 
     schedule(device, targets, updateId)
 
-    val operation = OperationResult(updateId.show, ERROR, "sad face")
+    val operation = OperationResult(updateId.show, 4, "sad face")
     val custom = CustomManifest(operation)
 
     val ecuManifestsTarget = ecuManifests.map { secu =>
@@ -341,13 +336,6 @@ trait DeviceResourceSpec extends DirectorSpec with KeyGenerators with DefaultPat
     updateManifestOk(device, deviceManifestTarget)
 
     coreClient.getReport(updateId) shouldBe Seq(operation)
-    fetchTargetsFor(device).signed.targets shouldBe empty
-
-    // schedule and confirm again
-    schedule(device, targets, updateId)
-    fetchTargetsFor(device).signed.targets shouldNot be(empty)
-    updateManifestOk(device, deviceManifestTarget)
-    fetchTargetsFor(device).signed.targets shouldBe empty
   }
 
   testWithNamespace("Device update to target counts as failed campaign") { implicit ns =>
@@ -385,8 +373,6 @@ trait DeviceResourceSpec extends DirectorSpec with KeyGenerators with DefaultPat
     coreClient.getReport(updateId).map(_.result_code) shouldBe Seq(4)
   }
 
-  val digester: MessageDigest = MessageDigest.getInstance("SHA-256")
-
   testWithNamespace("Update where the device is already") { implicit ns =>
     val device = DeviceId.generate()
     val primEcuReg = GenRegisterEcu.generate
@@ -402,20 +388,13 @@ trait DeviceResourceSpec extends DirectorSpec with KeyGenerators with DefaultPat
 
     updateManifestOk(device, deviceManifest)
 
-    val digest = Sha256Digest.digest(deviceManifest.signed.canonical.getBytes("UTF-8")).hash.value
-
-    processedManifestsRepository.contains(ns.get, device, digest).futureValue shouldBe true
-
     val targets = SetTarget(Map(primEcu -> CustomImage(ecuManifests.head.signed.installed_image, Uri(), None)))
     val updateId = UpdateId.generate
 
     schedule(device, targets, updateId)
-
-    processedManifestsRepository.contains(ns.get, device, digest).futureValue shouldBe false
-
     updateManifestOk(device, deviceManifest)
 
-    deviceVersion(device) should contain(1)
+    deviceVersion(device) shouldBe Some(1)
   }
 
   testWithNamespace("First Device can also update") { implicit ns =>
@@ -475,8 +454,8 @@ trait DeviceResourceSpec extends DirectorSpec with KeyGenerators with DefaultPat
     // currently device-current-target and device-update-target are both at 2
     // sending empty device manifest should not update device-current-target to 3
     updateManifestOk(device, deviceManifest2)
-    deviceVersion(device) should contain(2)
-    deviceScheduledVersion(device) shouldBe 2
+    deviceVersion(device) shouldBe Some(3)
+    deviceScheduledVersion(device) shouldBe 3
   }
 
   testWithNamespace("Device can get versioned root.json") { implicit ns =>


### PR DESCRIPTION
The previous fix didn't work because the aktualizr can send a manifest with error codes any time, thus deleting any newly added targets again on the server. This fix removes failed packages from the device targets on the server when a package install error arrives. Other errors than the one the customer encountered (like the aktualizr sending a completely wrong manifest) will have to be handled by a different ticket which requires more investigations.