### PR TITLE
bump libtuf

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= {
   val akkaHttpV = "10.0.11"
   val scalaTestV = "3.0.0"
   val bouncyCastleV = "1.57"
-  val tufV = "0.4.0-48-g578cd71"
+  val tufV = "0.4.0-66-g9e50fc3"
   val libatsV = "0.1.2-45-g9d5dbec"
   val circeConfigV = "0.0.2"
 

--- a/src/main/scala/com/advancedtelematic/director/daemon/DaemonBoot.scala
+++ b/src/main/scala/com/advancedtelematic/director/daemon/DaemonBoot.scala
@@ -16,7 +16,7 @@ import com.advancedtelematic.libats.http.monitoring.MetricsSupport
 import com.advancedtelematic.libats.messaging.{BusListenerMetrics, MessageBus, MessageListenerSupport}
 import com.advancedtelematic.libats.messaging_datatype.Messages.{BsDiffGenerationFailed, DeltaGenerationFailed, GeneratedBsDiff, GeneratedDelta, UserCreated}
 import com.advancedtelematic.libats.slick.monitoring.{DatabaseMetrics, DbHealthResource}
-import com.advancedtelematic.libtuf_server.data.Messages.TufTargetAdded
+import com.advancedtelematic.libtuf_server.data.Messages._
 import com.advancedtelematic.libtuf_server.keyserver.KeyserverHttpClient
 import com.advancedtelematic.metrics.{AkkaHttpRequestMetrics, InfluxdbMetricsReporterSupport}
 import com.advancedtelematic.metrics.prometheus.PrometheusMetricsSupport


### PR DESCRIPTION
This forces libtuf to use a newer version of libats, which does not
use lazy codec derivation for MessageLike, fixing the issue