### PR TITLE
Add tracing support, bump libtuf

### DIFF
--- a/SlickMapping.scala
+++ b/SlickMapping.scala
@@ -1,9 +1,0 @@
-package com.advancedtelematic.director.db
-
-import com.advancedtelematic.director.data.FileCacheRequestStatus
-import com.advancedtelematic.libats.slick.codecs.SlickEnumMapper
-
-object SlickMapping {
-  implicit val fileCacheRequestStatusMapper = SlickEnumMapper.enumMapper(FileCacheRequestStatus)
-}
-

--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,8 @@ libraryDependencies ++= {
   val akkaHttpV = "10.0.11"
   val scalaTestV = "3.0.0"
   val bouncyCastleV = "1.57"
-  val tufV = "0.5.0-4-gdd4744f"
-  val libatsV = "0.1.3-3-gc641236"
+  val tufV = "0.5.0-24-g1f23fad"
+  val libatsV = "0.1.3-11-g56c5530"
   val circeConfigV = "0.0.2"
 
   Seq(
@@ -35,6 +35,7 @@ libraryDependencies ++= {
     "com.advancedtelematic" %% "libats-messaging-datatype" % libatsV,
     "com.advancedtelematic" %% "libats-metrics-akka" % libatsV,
     "com.advancedtelematic" %% "libats-metrics-prometheus" % libatsV,
+    "com.advancedtelematic" %% "libats-http-tracing" % libatsV,
     "com.advancedtelematic" %% "libats-slick" % libatsV,
     "com.advancedtelematic" %% "libtuf" % tufV,
     "com.advancedtelematic" %% "libtuf-server" % tufV,

--- a/src/main/resources/db/migration/V20__drop_ecu_keytype.sql
+++ b/src/main/resources/db/migration/V20__drop_ecu_keytype.sql
@@ -1,0 +1,6 @@
+create table `ecus_rsa_keys` as
+select namespace, ecu_serial, cryptographic_method, public_key from `ecus`
+;
+
+alter table `ecus` drop column `cryptographic_method`
+;

--- a/src/main/scala/com/advancedtelematic/director/daemon/DaemonBoot.scala
+++ b/src/main/scala/com/advancedtelematic/director/daemon/DaemonBoot.scala
@@ -13,6 +13,7 @@ import com.advancedtelematic.libats.http.BootApp
 import com.advancedtelematic.libats.http.LogDirectives.logResponseMetrics
 import com.advancedtelematic.libats.http.VersionDirectives.versionHeaders
 import com.advancedtelematic.libats.http.monitoring.MetricsSupport
+import com.advancedtelematic.libats.http.tracing.NullRequestTracing
 import com.advancedtelematic.libats.messaging.{BusListenerMetrics, MessageBus, MessageListenerSupport}
 import com.advancedtelematic.libats.messaging_datatype.Messages.{BsDiffGenerationFailed, DeltaGenerationFailed, GeneratedBsDiff, GeneratedDelta, UserCreated}
 import com.advancedtelematic.libats.slick.monitoring.{DatabaseMetrics, DbHealthResource}
@@ -40,7 +41,7 @@ object DaemonBoot extends BootApp
 
   implicit val msgPublisher = MessageBus.publisher(system, config)
 
-  val tuf = KeyserverHttpClient(tufUri)
+  val tuf = KeyserverHttpClient(tufUri)(system, materializer, new NullRequestTracing)
   val diffService = new DiffServiceDirectorClient(tufBinaryUri)
   val rolesGeneration = new RolesGeneration(tuf, diffService)
 

--- a/src/main/scala/com/advancedtelematic/director/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/DataType.scala
@@ -50,10 +50,7 @@ object DataType {
                                 ecuIdentifiers: Map[EcuSerial, TargetCustomUri])
 
   final case class Ecu(ecuSerial: EcuSerial, device: DeviceId, namespace: Namespace, primary: Boolean,
-                       hardwareId: HardwareIdentifier, tufKey: TufKey) {
-    def keyType = tufKey.keytype
-    def publicKey = tufKey.keyval
-  }
+                       hardwareId: HardwareIdentifier, tufKey: TufKey)
 
   final case class CurrentImage (namespace: Namespace, ecuSerial: EcuSerial, image: Image, attacksDetected: String)
 

--- a/src/main/scala/com/advancedtelematic/director/db/EcuKeysToJsonEncodedMigration.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/EcuKeysToJsonEncodedMigration.scala
@@ -1,0 +1,76 @@
+package com.advancedtelematic.director.db
+
+import java.security.PublicKey
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.util.FastFuture
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Sink, Source}
+import akka.{Done, NotUsed}
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.messaging_datatype.DataType.EcuSerial
+import com.advancedtelematic.libats.slick.codecs.SlickRefined._
+import com.advancedtelematic.libtuf.crypt.TufCrypto
+import com.advancedtelematic.libtuf.data.TufCodecs._
+import com.advancedtelematic.libtuf.data.TufDataType.{RSATufKey, TufKey}
+import io.circe.syntax._
+import org.slf4j.LoggerFactory
+import slick.jdbc.MySQLProfile.api._
+import slick.jdbc.{GetResult, PositionedParameters, SetParameter}
+import com.advancedtelematic.libats.slick.db.SlickAnyVal._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+
+class EcuKeysToJsonEncodedMigration(implicit
+                                    val db: Database,
+                                    val mat: Materializer,
+                                    val system: ActorSystem,
+                                    val ec: ExecutionContext) {
+
+  private val _log = LoggerFactory.getLogger(this.getClass)
+
+  def writeKey(ecuSerial: EcuSerial, ns: Namespace, publicKey: PublicKey)(implicit db: Database): Future[TufKey] = {
+    implicit val setRsaKey: SetParameter[TufKey] = (tufKey: TufKey, pp: PositionedParameters) => {
+      pp.setString(tufKey.asJson.noSpaces)
+    }
+
+    val rsaKey = RSATufKey(publicKey)
+    val sql = sqlu"""update `ecus` set public_key = $rsaKey where ecu_serial = '#${ecuSerial.value}' and namespace = '#${ns.get}'"""
+
+    db.run(sql).flatMap {
+      case 1 => FastFuture.successful(rsaKey)
+      case _ => FastFuture.failed(new RuntimeException(s"Could not update key format. $ecuSerial $ns"))
+    }
+  }
+
+  def existingKeys(implicit db: Database):  Source[(EcuSerial, Namespace, PublicKey), NotUsed] = {
+    implicit val getResult: GetResult[(EcuSerial, Namespace, String)] = pr => {
+      val ecuSerial = implicitly[ColumnType[EcuSerial]].getValue(pr.rs, 1)
+      val namespace = implicitly[ColumnType[Namespace]].getValue(pr.rs, 2)
+      (ecuSerial, namespace, pr.rs.getString("public_key"))
+    }
+
+    val findQ = sql"""select ecu_serial, namespace, public_key from `ecus`""".as[(EcuSerial, Namespace, String)]
+
+    Source.fromPublisher(db.stream(findQ)).mapConcat {
+      case (serial, ns, pubkeyStr) =>
+        TufCrypto.parsePublicPem(pubkeyStr) match {
+          case Success(k) => Vector((serial, ns, k))
+          case Failure(err) =>
+            _log.error(s"Could not parse public key for $serial", err)
+            Vector.empty
+        }
+    }
+  }
+
+  def run: Future[Done] = {
+    val source = existingKeys.mapAsync(1)((writeKey _).tupled)
+
+    source.runWith(Sink.foreach { key =>
+      _log.info(s"Converted ${key.id} to new format")
+    })
+  }
+}
+

--- a/src/main/scala/com/advancedtelematic/director/db/SlickMapping.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/SlickMapping.scala
@@ -1,0 +1,32 @@
+package com.advancedtelematic.director.db
+
+import java.io.StringWriter
+import java.security.PublicKey
+
+import com.advancedtelematic.director.data.FileCacheRequestStatus
+import com.advancedtelematic.libats.data.DataType.HashMethod
+import com.advancedtelematic.libats.data.DataType.HashMethod.HashMethod
+import com.advancedtelematic.libtuf.crypt.TufCrypto
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter
+import slick.jdbc.MySQLProfile.api._
+
+object SlickMapping {
+  import com.advancedtelematic.libats.slick.codecs.SlickEnumMapper
+  import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat
+
+  implicit val hashMethodColumn = MappedColumnType.base[HashMethod, String](_.toString, HashMethod.withName)
+  implicit val targetFormatMapper = SlickEnumMapper.enumMapper(TargetFormat)
+
+  implicit val publicKeyMapper = MappedColumnType.base[PublicKey, String](
+    { publicKey => {
+      val pemStrWriter = new StringWriter()
+      val jcaPEMWriter = new JcaPEMWriter(pemStrWriter)
+      jcaPEMWriter.writeObject(publicKey)
+      jcaPEMWriter.flush()
+      pemStrWriter.toString
+    } },
+    {str => TufCrypto.parsePublicPem(str).get}
+  )
+
+  implicit val fileCacheRequestStatusMapper = SlickEnumMapper.enumMapper(FileCacheRequestStatus)
+}

--- a/src/main/scala/com/advancedtelematic/director/manifest/SignatureVerification.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/SignatureVerification.scala
@@ -17,7 +17,7 @@ object SignatureVerification {
     }
 
     Try {
-      TufCrypto.isValid(sig, clientKey.keyval, data)
+      TufCrypto.isValid(sig, clientKey, data)
     }.recover {
       case x: SignatureException => false
       case TufCrypto.SignatureMethodMismatch(from, to) => false

--- a/src/main/scala/com/advancedtelematic/director/roles/RolesGeneration.scala
+++ b/src/main/scala/com/advancedtelematic/director/roles/RolesGeneration.scala
@@ -65,7 +65,7 @@ class RolesGeneration(tuf: KeyserverClient, diffService: DiffServiceClient)
       ClientTargetItem(fileInfo.hashes.toClientHashes, fileInfo.length, Some(targetCustom.asJson))
     }
 
-    TargetsRole(expires, clientTargetItems, targetVersion, custom.map(_.asJson))
+    TargetsRole(expires, clientTargetItems, targetVersion, custom = custom.map(_.asJson))
   }
 
   private def snapshotRole(targetsRole: SignedPayload[TargetsRole], version: Int, expires: Instant): SnapshotRole =

--- a/src/main/scala/db/migration/R__MigrateEcuKeysToJsonEncoded.scala
+++ b/src/main/scala/db/migration/R__MigrateEcuKeysToJsonEncoded.scala
@@ -1,0 +1,20 @@
+package db.migration
+
+import java.security.Security
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.advancedtelematic.director.db.EcuKeysToJsonEncodedMigration
+import com.advancedtelematic.libats.slick.db.AppMigration
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import slick.jdbc.MySQLProfile.api._
+
+class R__MigrateEcuKeysToJsonEncoded extends AppMigration  {
+  Security.addProvider(new BouncyCastleProvider)
+
+  implicit val system = ActorSystem(this.getClass.getSimpleName)
+  implicit val materializer = ActorMaterializer()
+  import system.dispatcher
+
+  override def migrate(implicit db: Database) = new EcuKeysToJsonEncodedMigration().run.map(_ => ())
+}

--- a/src/test/scala/com/advancedtelematic/director/client/FakeKeyserverClient.scala
+++ b/src/test/scala/com/advancedtelematic/director/client/FakeKeyserverClient.scala
@@ -7,7 +7,6 @@ import java.util.concurrent.ConcurrentHashMap
 import akka.http.scaladsl.util.FastFuture
 import com.advancedtelematic.director.data.Generators
 import com.advancedtelematic.libtuf.crypt.TufCrypto
-import com.advancedtelematic.libtuf.crypt.TufCrypto.PublicKeyOps
 import com.advancedtelematic.libtuf.data.ClientCodecs._
 import com.advancedtelematic.libtuf.data.ClientDataType.{RoleKeys, RootRole}
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
@@ -49,7 +48,7 @@ class FakeKeyserverClient extends KeyserverClient with Generators {
     }
 
     val clientKeys = keys.get(repoId).map { case (_, keyPair) =>
-      keyPair.pubkey.keyval.id -> keyPair.pubkey
+      keyPair.pubkey.id -> keyPair.pubkey
     }
 
     RootRole(clientKeys, roles, expires = Instant.now.plusSeconds(3600), version = 1)

--- a/src/test/scala/com/advancedtelematic/director/db/EcuKeysToJsonEncodedMigrationSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/db/EcuKeysToJsonEncodedMigrationSpec.scala
@@ -1,0 +1,84 @@
+package com.advancedtelematic.director.db
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKitBase
+import com.advancedtelematic.libats.data.DataType
+import com.advancedtelematic.libats.data.RefinedUtils._
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, ValidEcuSerial}
+import com.advancedtelematic.libats.test.{DatabaseSpec, LongTest}
+import com.advancedtelematic.libtuf.data.TufDataType.{RSATufKey, ValidKeyId}
+import org.scalatest.concurrent.{PatienceConfiguration, ScalaFutures}
+import org.scalatest.{FunSuite, Matchers}
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.ExecutionContext
+
+class EcuKeysToJsonEncodedMigrationSpec extends FunSuite with TestKitBase with DatabaseSpec with PatienceConfiguration with LongTest with ScalaFutures with DeviceRepositorySupport with Matchers {
+
+  override implicit lazy val system: ActorSystem = ActorSystem(this.getClass.getSimpleName)
+
+  implicit val mat = ActorMaterializer()
+
+  implicit val ec = ExecutionContext.Implicits.global
+
+  val migration = new EcuKeysToJsonEncodedMigration()
+
+  val ns = DataType.Namespace("migrationns")
+
+  test("updates a key from old encoding to new encoding") {
+    val device = DeviceId.generate()
+    val serial = "cxJvjrQeNqwcct".refineTry[ValidEcuSerial].get
+
+    val sql =
+      sqlu"""insert into `ecus` (ecu_serial, device, namespace, `primary`, public_key, hardware_identifier) VALUES (
+            '#${serial.value}',
+            '#${device.uuid.toString}',
+            '#${ns.get}',
+            1,
+            '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwfwpnCmgkCflw3MA8+bn\nI9JKjBxiHrQNCt1IkZxf7vMnrUumeuI9QTrgkLDrHC83gcWq9V3hBd4oCFSBXYa7\nr/00E7xXgSxiFRctWhQbOBRnH/Kqd+NcB6oYayJMoacsFB19Y45R/TxxkpyzZF2O\n9lWYju7nuFqSWv0sdoZ9a7vxisaAIUzflPscnTxeMN5TQSlnI5cltmLt8ZD1g1rn\nix2C5PaFaEgucL8qFfds6azbutP4gLu4b7iqSV7s+k1akP5ygr+6Yq4Bu6QFUOdn\nooLdiA5C5EvW6D5cPW+nSVmMgwWJ4EILCLlN8gIxWI/qbWpG/DXg2fTAGQ+GLaFm\nXQIDAQAB\n-----END PUBLIC KEY-----\n',
+            'somehwid'
+            );"""
+
+    db.run(sql).futureValue
+
+    migration.run.futureValue
+
+    deviceRepository.findEcus(ns, device).futureValue.head.tufKey shouldBe a[RSATufKey]
+  }
+
+  test("migrations run with multiple keys") {
+    val device = DeviceId.generate()
+
+    val serial0 = "oneserial".refineTry[ValidEcuSerial].get
+
+    val sql0 =
+      sqlu"""insert into `ecus` (ecu_serial, device, namespace, `primary`, public_key, hardware_identifier) VALUES (
+            '#${serial0.value}',
+            '#${device.uuid.toString}',
+            '#${ns.get}',
+            1,
+            '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxgmP1Ohroaz+FijPr/JP\nBfYvXHB3EmyqMTvr6IopMWyr2EZreUxVYOyvf+8KiktqsjOfRrnCf6UGiqTqhPQk\nzJnWaLGcIA45DrgzDX99V27eFhLXdRIcLaFyhVDc9CyS75Jz5krPkPnLO6MVDBOD\nxq7nG0zPBj6YV3IBrTR1uDjJAIKdTiHs+kLHLI6E1QdR7FYKXShfSd/9+xgtX35g\n1HIlG2FBxH9uIZDVIkOvy2/d8hjix6JwuETTQmVQHY/BAHctq9pJp+ukHxxkZtLw\ngGjhyBivkywdXF6vfYcER/cexFUni0Oa6YtWCj/Fl6Kp+yFBxxFhX3Go9D+jgecy\nUwIDAQAB\n-----END PUBLIC KEY-----',
+            'somehwid'
+            );"""
+
+    val serial1 = "anotherserial".refineTry[ValidEcuSerial].get
+
+    val sql1 =
+      sqlu"""insert into `ecus` (ecu_serial, device, namespace, `primary`, public_key, hardware_identifier) VALUES (
+            '#${serial1.value}',
+            '#${device.uuid.toString}',
+            '#${ns.get}',
+            1,
+            '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvcHcea881D6O7PyoymuC\nBG9pVw344h0rOvnWVxzMcQcpMj9dDwdRvDjLo0xLAbmB5/gOZizzkG2wLKAvzYec\naPz6fSZdmRPxvbWxKQo9InqYI0LMbiRxQt+85sjea4FKOZ3NPbzoTHBUvASGle1K\nTA3Mzo/TQCHwHwX+IfkVsrjtmdgVmgWtenGFjiKb7rhi1Z7GEOeB4WnfGZ3dAEek\ngegw8oY+iITqY/7K2lDBu8koH/LIEbb1gyMb/SnMnYM6g023Pl/KruRULn9PBVtv\nrUzBTlLX9C8AHI/iCkdGy1462TI/QHBxujGrYSVWpOpFpYy4xu+kJv4WhzqBX/yt\nHQIDAQAB\n-----END PUBLIC KEY-----',
+            'somehwid'
+            );"""
+
+    db.run(DBIO.seq(sql0, sql1)).futureValue
+
+    migration.run.futureValue
+
+    deviceRepository.findEcus(ns, device).futureValue.map(_.tufKey.id.value) should contain("096d9548802470a5595ad1a54c8ae6e2b80dc7060ca5c2a91c7132573d109f6b")
+    deviceRepository.findEcus(ns, device).futureValue.map(_.tufKey.id.value) should contain("734b8e46357c1e3c60bbfe2dd7bd57ffdf338cb55eba6f2c7756a5d36e92e88d")
+  }
+}

--- a/src/test/scala/com/advancedtelematic/director/db/FileCacheDB.scala
+++ b/src/test/scala/com/advancedtelematic/director/db/FileCacheDB.scala
@@ -9,7 +9,6 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.MySQLProfile.api._
-
 import SlickMapping._
 
 trait FileCacheDB {


### PR DESCRIPTION
Bumps libtuf to latest version. The latest libtuf simplifies a TufCrypto a bit and no longer provides `convert` methods to convert from a `java.security.PublicKey` to a `TufKey`, this method was used by director to store a `java.security.PublicKey` in the database. Director also needed to separately store a keytype, so it would know which `TufCrypto` instance to call the `convert` method on. The `java.security.PublicKey` itself was stored using  Pem(X509Encoded) format to write the key to the db, this format is usually only used for RSA keys.

This change makes director store the keys in the database using json, saving them using `TufKey` instead of `java.security.PublicKey`, using a standard json encoder we use for other json types. This means that:

- the keytype column is no longer needed, as the keytype is encoded in the json payload saved to the `public_key` column
- all key types can be written to the database, there are two concrete instances of `TufKey`, rsa and ed25519, more can be added, but as long as the circe decoder is implemented, they can be written to the database by director
- libtuf can then be bumped as director no longer depends on `TufCrypto.convert`

This needed a migration to convert the keys from Pem(X509Encoded) to a json encoded TufKey. Since we only have RSA keys in the database, the migration only migrates RSA keys. It does so by reading the Pem(X509Encoded) payload and converting it to a TufKey and then writing the key with the circe encoder.