### PR TITLE
Remove copyTargets in AdminRepository

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/db/CancelUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/CancelUpdate.scala
@@ -20,7 +20,6 @@ class CancelUpdate(implicit db: Database, ec: ExecutionContext) extends AdminRep
       } else for {
         latestVersion <- adminRepository.getLatestScheduledVersion(namespace, device)
         nextTimestampVersion = latestVersion + 1
-        _ <- adminRepository.copyTargetsAction(namespace, device, current, nextTimestampVersion)
         _ <- adminRepository.updateDeviceTargetsAction(device, None, None, nextTimestampVersion)
         _ <- deviceRepository.updateDeviceVersionAction(device, nextTimestampVersion)
       } yield Some(device)

--- a/src/main/scala/com/advancedtelematic/director/manifest/AfterUpdate.scala
+++ b/src/main/scala/com/advancedtelematic/director/manifest/AfterUpdate.scala
@@ -6,12 +6,9 @@ import cats.implicits._
 import com.advancedtelematic.director.data.MessageDataType.UpdateStatus
 import com.advancedtelematic.director.data.Messages.UpdateSpec
 import com.advancedtelematic.director.db.{AdminRepositorySupport, DeviceRepositorySupport, DeviceUpdate}
-import com.advancedtelematic.libats.data.EcuIdentifier
-import com.advancedtelematic.libats.data.RefinedUtils._
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
 import com.advancedtelematic.libats.messaging_datatype.DataType.InstallationResult
 import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceInstallationReport
-import com.advancedtelematic.libtuf.data.TufDataType.{TargetFilename, ValidTargetFilename}
 import slick.driver.MySQLDriver.api._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -34,8 +31,7 @@ class AfterDeviceManifestUpdate()
   private def clearFailedUpdate(report: DeviceInstallationReport) =
     for {
       version <- deviceRepository.getCurrentVersion(report.device)
-      failedTargets = toFailedTargets(report)
-      lastVersion <- DeviceUpdate.clearTargetsFrom(report.namespace, report.device, version, failedTargets)
+      lastVersion <- DeviceUpdate.clearTargetsFrom(report.namespace, report.device, version)
       // TODO: Properly implement multiple updates queued per device.
       // Currently there can be only one update queued per device,
       // so the following code should not be run.
@@ -50,12 +46,6 @@ class AfterDeviceManifestUpdate()
             Map(), None, Instant.now))
       }
     } yield ()
-
-  private def toFailedTargets(report: DeviceInstallationReport) : Map[EcuIdentifier, TargetFilename] = {
-    report.ecuReports
-      .filterNot(_._2.result.success)
-      .mapValues { report => report.target.head.refineTry[ValidTargetFilename].get }
-  }
 
   private def publishReport(report: DeviceInstallationReport) = {
     for {


### PR DESCRIPTION
Director should not try to reset devices to previous targets.json
on failed or canceled updates. In this case, return empty targets.json.

Signed-off-by: Jerry Trieu <jerry.trieu@here.com>