### PR TITLE
Move to {Device,Ecu}TargetRepository

### DIFF
--- a/src/main/resources/db/migration/V21__ecu_update_targets.sql
+++ b/src/main/resources/db/migration/V21__ecu_update_targets.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `ecu_update_targets` (
+  `namespace` varchar(200) NOT NULL,
+  `device_id` char(36) NOT NULL,
+  `ecu_id` varchar(64) NOT NULL,
+  `version` int NOT NULL,
+  `filepath` varchar(4096) NOT NULL,
+  `length` int NOT NULL,
+  `checksum` varchar(254) NOT NULL,
+  `uri` VARCHAR(254) NOT NULL,
+  `diff_format` ENUM('OSTREE', 'BINARY') NULL,
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+  PRIMARY KEY (`namespace`, `device_id`, `ecu_id`, `version`)
+) DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/src/main/scala/com/advancedtelematic/director/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/director/data/DataType.scala
@@ -58,6 +58,12 @@ object DataType {
 
   final case class EcuTarget(namespace: Namespace, version: Int, ecuIdentifier: EcuIdentifier, customImage: CustomImage)
 
+  final case class EcuUpdateTarget(namespace: Namespace,
+                                   deviceId: DeviceId,
+                                   ecuIdentifier: EcuIdentifier,
+                                   version: Int,
+                                   customImage: CustomImage)
+
   final case class DeviceUpdateTarget(device: DeviceId, correlationId: Option[CorrelationId], updateId: Option[UpdateId], targetVersion: Int, inFlight: Boolean)
 
   final case class DeviceCurrentTarget(device: DeviceId, targetVersion: Int)

--- a/src/main/scala/com/advancedtelematic/director/db/DeviceTargetRepository.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/DeviceTargetRepository.scala
@@ -1,0 +1,78 @@
+package com.advancedtelematic.director.db
+
+import com.advancedtelematic.director.data.DataType.DeviceUpdateTarget
+import com.advancedtelematic.libats.data.DataType.{CorrelationId, Namespace}
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
+import com.advancedtelematic.libats.slick.codecs.SlickRefined._
+import com.advancedtelematic.libats.slick.db.SlickAnyVal._
+import com.advancedtelematic.libats.slick.db.SlickExtensions._
+import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
+import com.advancedtelematic.libats.slick.db.SlickValidatedGeneric.validatedStringMapper
+
+import scala.concurrent.{ExecutionContext, Future}
+import slick.jdbc.MySQLProfile.api._
+import com.advancedtelematic.director.db.SlickMapping._
+
+import Errors._
+
+trait DeviceTargetRepositorySupport {
+  def deviceTargetRepository(implicit db: Database, ec: ExecutionContext) = new DeviceTargetRepository()
+}
+
+protected class DeviceTargetRepository()(implicit db: Database, ec: ExecutionContext) {
+  import Schema.deviceTargets
+
+  def exists(namespace: Namespace, device: DeviceId, version: Int): Future[Boolean] =
+    db.run(existsAction(namespace, device, version))
+
+  protected [db] def existsAction(namespace: Namespace, device: DeviceId, version: Int): DBIO[Boolean] =
+    deviceTargets
+      .filter(_.device === device)
+      .filter(_.version === version)
+      .exists
+      .result
+
+  protected [db] def persistAction(device: DeviceId, correlationId: Option[CorrelationId], updateId: Option[UpdateId], version: Int): DBIO[DeviceUpdateTarget] = {
+    val target = DeviceUpdateTarget(device, correlationId, updateId, version, inFlight = false)
+
+    (deviceTargets += target)
+      .map(_ => target)
+      .handleIntegrityErrors(ConflictingTarget)
+  }
+
+  protected [db] def fetchLatestAction(namespace: Namespace, deviceId: DeviceId): DBIO[Int] =
+    deviceTargets
+      .filter(_.device === deviceId)
+      .map(_.version)
+      .forUpdate
+      .max
+      .result
+      .failIfNone(NoTargetsScheduled)
+
+  protected [db] def fetchAction(namespace: Namespace, device: DeviceId, version: Int): DBIO[DeviceUpdateTarget] =
+    deviceTargets
+      .filter(_.device === device)
+      .filter(_.version === version)
+      .result
+      .failIfMany
+      .failIfNone(NoTargetsScheduled)
+
+
+  protected [db] def fetchAllAfterAction(deviceId: DeviceId, fromVersion: Int): DBIO[Seq[DeviceUpdateTarget]] =
+    deviceTargets
+      .filter(_.device === deviceId)
+      .filter(_.version > fromVersion)
+      .sortBy(_.version)
+      .result
+
+  def getUpdatesFromTo(namespace: Namespace, device: DeviceId, fromVersion: Int, toVersion: Int)
+    : Future[Seq[DeviceUpdateTarget]] = db.run {
+    Schema.deviceTargets
+      .filter(_.device === device)
+      .filter(_.version > fromVersion)
+      .filter(_.version <= toVersion)
+      .sortBy(_.version)
+      .result
+  }
+}
+

--- a/src/main/scala/com/advancedtelematic/director/db/EcuTargetRepository.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/EcuTargetRepository.scala
@@ -1,0 +1,83 @@
+package com.advancedtelematic.director.db
+
+import com.advancedtelematic.director.data.AdminRequest.QueueResponse
+import com.advancedtelematic.director.data.DataType.{CustomImage, DeviceUpdateTarget, EcuUpdateTarget}
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.data.EcuIdentifier
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.libats.slick.codecs.SlickRefined._
+import com.advancedtelematic.libats.slick.db.SlickAnyVal._
+import com.advancedtelematic.libats.slick.db.SlickExtensions._
+import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
+import com.advancedtelematic.libats.slick.db.SlickValidatedGeneric.validatedStringMapper
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+import slick.jdbc.MySQLProfile.api._
+
+import Errors._
+
+trait EcuTargetRepositorySupport {
+  def ecuTargetRepository(implicit db: Database, ec: ExecutionContext) = new EcuTargetRepository()
+}
+
+protected class EcuTargetRepository()(implicit val db: Database, val ec: ExecutionContext)
+  extends DeviceTargetRepositorySupport {
+
+  import Schema.ecuUpdateTarget
+
+  private [this] def persistAction(
+    namespace: Namespace, deviceId: DeviceId, version: Int, targets: Map[EcuIdentifier, CustomImage]
+  ): DBIO[Unit] = {
+
+    val act = (ecuUpdateTarget ++= targets.map {
+      case (ecuSerial, customImage) => EcuUpdateTarget(namespace, deviceId, ecuSerial, version, customImage)
+    })
+
+    act.map(_ => ()).transactionally
+  }
+
+  protected [db] def persistAction(
+    namespace: Namespace, deviceId: DeviceId, targets: Map[EcuIdentifier, CustomImage])
+  : DBIO[Int] = for {
+    version <- deviceTargetRepository.fetchLatestAction(namespace, deviceId).asTry.flatMap {
+      case Success(x) => DBIO.successful(x)
+      case Failure(NoTargetsScheduled) => DBIO.successful(0)
+      case Failure(ex) => DBIO.failed(ex)
+    }
+    new_version = version + 1
+    _ <- persistAction(namespace, deviceId, new_version, targets)
+  } yield new_version
+
+  protected [db] def fetchAction(namespace: Namespace, device: DeviceId, version: Int): DBIO[Map[EcuIdentifier, CustomImage]] =
+    ecuUpdateTarget
+      .filter(_.namespace === namespace)
+      .filter(_.deviceId === device)
+      .filter(_.version === version)
+      .map { ecuTarget => ecuTarget.ecuId -> ecuTarget.customImage }
+      .result
+      .map(_.toMap)
+
+  def fetch(namespace: Namespace, device: DeviceId, version: Int): Future[Map[EcuIdentifier, CustomImage]] =
+    db.run(fetchAction(namespace, device, version))
+
+  def fetchQueue(namespace: Namespace, device: DeviceId): Future[Seq[QueueResponse]] = db.run {
+    def queueResult(updateTarget: DeviceUpdateTarget): DBIO[QueueResponse] = for {
+      targets <- fetchAction(namespace, device, updateTarget.targetVersion)
+    } yield QueueResponse(updateTarget.correlationId, targets, updateTarget.inFlight)
+
+    val versionOfDevice: DBIO[Int] = Schema.deviceCurrentTarget
+      .filter(_.device === device)
+      .map(_.deviceCurrentTarget)
+      .result
+      .failIfMany
+      .map(_.getOrElse(0))
+
+    for {
+      currentVersion <- versionOfDevice
+      updates <- deviceTargetRepository.fetchAllAfterAction(device, currentVersion)
+      queue <- DBIO.sequence(updates.map(queueResult))
+    } yield queue
+  }
+}
+

--- a/src/main/scala/com/advancedtelematic/director/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Schema.scala
@@ -105,6 +105,30 @@ object Schema {
   }
   protected [db] val ecuTargets = TableQuery[EcuTargetsTable]
 
+  class EcuUpdateTargetTable(tag: Tag) extends Table[EcuUpdateTarget](tag, "ecu_update_targets") {
+    def namespace  = column[Namespace]("namespace")
+    def deviceId = column[DeviceId]("device_id")
+    def ecuId = column[EcuIdentifier]("ecu_id")
+    def version = column[Int]("version")
+    def filepath = column[TargetFilename]("filepath")
+    def length = column[Long]("length")
+    def checksum = column[Checksum]("checksum")
+    def uri = column[Uri]("uri")
+    def diffFormat = column[Option[TargetFormat]]("diff_format")
+
+    def fileInfo = (checksum, length) <>
+      ( { case (checksum, length) => FileInfo(Hashes(checksum.hash), length)},
+        (x: FileInfo) => Some((Checksum(HashMethod.SHA256, x.hashes.sha256), x.length))
+      )
+
+    def image = (filepath, fileInfo) <> ((Image.apply _).tupled, Image.unapply)
+
+    def customImage = (image, uri, diffFormat) <> ((CustomImage.apply _).tupled, CustomImage.unapply)
+
+    override def * = (namespace, deviceId, ecuId, version, customImage) <> ((EcuUpdateTarget.apply _).tupled, EcuUpdateTarget.unapply)
+  }
+  protected [db] val ecuUpdateTarget = TableQuery[EcuUpdateTargetTable]
+
   class DeviceUpdateTargetsTable(tag: Tag) extends Table[DeviceUpdateTarget](tag, "device_update_targets") {
     def device = column[DeviceId]("device")
     def correlationId = column[Option[CorrelationId]]("correlation_id")

--- a/src/main/scala/com/advancedtelematic/director/http/AdminResource.scala
+++ b/src/main/scala/com/advancedtelematic/director/http/AdminResource.scala
@@ -36,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class AdminResource(extractNamespace: Directive1[Namespace], val keyserverClient: KeyserverClient)
                    (implicit val db: Database, val ec: ExecutionContext, messageBusPublisher: MessageBusPublisher)
     extends AdminRepositorySupport
+    with EcuTargetRepositorySupport
     with AutoUpdateRepositorySupport
     with DeviceRepositorySupport
     with FileCacheRequestRepositorySupport
@@ -164,7 +165,7 @@ class AdminResource(extractNamespace: Directive1[Namespace], val keyserverClient
   }
 
   def queueForDevice(namespace: Namespace, device: DeviceId): Route = {
-    val f = adminRepository.findQueue(namespace, device)
+    val f = ecuTargetRepository.fetchQueue(namespace, device)
     complete(f)
   }
 

--- a/src/main/scala/com/advancedtelematic/director/http/AssignmentsResource.scala
+++ b/src/main/scala/com/advancedtelematic/director/http/AssignmentsResource.scala
@@ -6,7 +6,7 @@ import com.advancedtelematic.director.data.Codecs._
 import com.advancedtelematic.director.data.AdminRequest.AssignUpdateRequest
 import com.advancedtelematic.director.data.MessageDataType.UpdateStatus
 import com.advancedtelematic.director.data.Messages.UpdateSpec
-import com.advancedtelematic.director.db.{AdminRepositorySupport, CancelUpdate, SetMultiTargets}
+import com.advancedtelematic.director.db.{EcuTargetRepositorySupport, CancelUpdate, SetMultiTargets}
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.http.UUIDKeyAkka._
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
@@ -19,8 +19,8 @@ import slick.jdbc.MySQLProfile.api.Database
 import scala.concurrent.{ExecutionContext, Future}
 
 class AssignmentsResource(extractNamespace: Directive1[Namespace])
-(implicit db: Database, ec: ExecutionContext, messageBusPublisher: MessageBusPublisher)
-  extends AdminRepositorySupport {
+(implicit val db: Database, val ec: ExecutionContext, messageBusPublisher: MessageBusPublisher)
+  extends EcuTargetRepositorySupport {
 
   import Directives._
 
@@ -66,7 +66,7 @@ class AssignmentsResource(extractNamespace: Directive1[Namespace])
       } ~
       pathPrefix(DeviceId.Path) { deviceId =>
         get {
-          val f = adminRepository.findQueue(ns, deviceId)
+          val f = ecuTargetRepository.fetchQueue(ns, deviceId)
           complete(f)
         } ~
         delete {

--- a/src/test/scala/com/advancedtelematic/director/http/SetMultiTargetSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/SetMultiTargetSpec.scala
@@ -5,7 +5,7 @@ import com.advancedtelematic.director.data.AdminRequest.RegisterDevice
 import com.advancedtelematic.director.data.DataType._
 import com.advancedtelematic.director.data.GeneratorOps._
 import com.advancedtelematic.director.data.{EdGenerators, KeyGenerators, RsaGenerators}
-import com.advancedtelematic.director.db.{AdminRepositorySupport, DeviceRepositorySupport, SetMultiTargets}
+import com.advancedtelematic.director.db.{AdminRepositorySupport, DeviceRepositorySupport, DeviceTargetRepositorySupport, EcuTargetRepositorySupport, SetMultiTargets}
 import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, RouteResourceSpec}
 import com.advancedtelematic.libats.data.DataType.MultiTargetUpdateId
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
@@ -14,6 +14,8 @@ trait SetMultiTargetSpec extends DirectorSpec
     with KeyGenerators
     with AdminRepositorySupport
     with DeviceRepositorySupport
+    with DeviceTargetRepositorySupport
+    with EcuTargetRepositorySupport
     with DefaultPatience
     with RouteResourceSpec
     with Requests {
@@ -35,7 +37,7 @@ trait SetMultiTargetSpec extends DirectorSpec
     val mtuId = createMultiTargetUpdateOK(mtu)
 
     setMultiTargets.setMultiUpdateTargets(defaultNs, device, mtuId, MultiTargetUpdateId(mtuId.uuid)).futureValue
-    val update = adminRepository.fetchTargetVersion(defaultNs, device, 1).futureValue
+    val update = ecuTargetRepository.fetch(defaultNs, device, 1).futureValue
 
     update shouldBe Map(primEcu -> CustomImage(targetUpdate.to.image, Uri(), None))
   }
@@ -64,10 +66,10 @@ trait SetMultiTargetSpec extends DirectorSpec
 
     affected.toSet shouldBe Set(device0, device1)
 
-    val update0 = adminRepository.fetchTargetVersion(defaultNs, device0, 1).futureValue
+    val update0 = ecuTargetRepository.fetch(defaultNs, device0, 1).futureValue
     update0 shouldBe Map(primEcu0 -> CustomImage(targetUpdate.to.image, Uri(), None))
 
-    val update1 = adminRepository.fetchTargetVersion(defaultNs, device1, 1).futureValue
+    val update1 = ecuTargetRepository.fetch(defaultNs, device1, 1).futureValue
     update1 shouldBe Map(primEcu1 -> CustomImage(targetUpdate.to.image, Uri(), None))
   }
 
@@ -94,7 +96,7 @@ trait SetMultiTargetSpec extends DirectorSpec
     }.toMap
 
     setMultiTargets.setMultiUpdateTargets(defaultNs, device, updateId, MultiTargetUpdateId(updateId.uuid)).futureValue
-    val update = adminRepository.fetchTargetVersion(defaultNs, device, 1).futureValue
+    val update = ecuTargetRepository.fetch(defaultNs, device, 1).futureValue
     update shouldBe expected
   }
 
@@ -122,7 +124,7 @@ trait SetMultiTargetSpec extends DirectorSpec
       }.toMap
 
       setMultiTargets.setMultiUpdateTargets(defaultNs, device, updateId, MultiTargetUpdateId(updateId.uuid)).futureValue
-      val update = adminRepository.fetchTargetVersion(defaultNs, device, 1).futureValue
+      val update = ecuTargetRepository.fetch(defaultNs, device, 1).futureValue
       update shouldBe expected
     }
 
@@ -136,7 +138,7 @@ trait SetMultiTargetSpec extends DirectorSpec
       }.toMap
 
       setMultiTargets.setMultiUpdateTargets(defaultNs, device, updateId, MultiTargetUpdateId(updateId.uuid)).futureValue
-      val update = adminRepository.fetchTargetVersion(defaultNs, device, 2).futureValue
+      val update = ecuTargetRepository.fetch(defaultNs, device, 2).futureValue
       update shouldBe expected
     }
   }
@@ -160,7 +162,7 @@ trait SetMultiTargetSpec extends DirectorSpec
     val mtuId = createMultiTargetUpdateOK(mtu)
 
     setMultiTargets.setMultiUpdateTargets(defaultNs, device, mtuId, MultiTargetUpdateId(mtuId.uuid)).futureValue
-    val update = adminRepository.fetchTargetVersion(defaultNs, device, 1).futureValue
+    val update = ecuTargetRepository.fetch(defaultNs, device, 1).futureValue
     update shouldBe Map(primEcu -> CustomImage(targetUpdate.to.image, Uri(), None))
 
     val ecuManifestTarget = Seq(GenSignedEcuManifestWithImage(primEcu, targetUpdate.to.image).generate)


### PR DESCRIPTION
Built on #157 

This refactoring adds a new table that contains both `deviceId`,`ecuId` to determine targets version for a device. This change will enable removing the `ecus` table which we are moving to `device-registry`.

TODO: Migration of old tables to new table
