### PR TITLE
Use namespace when joining on `current_images`

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Repository.scala
@@ -100,7 +100,7 @@ protected class AdminRepository()(implicit db: Database, ec: ExecutionContext) e
   def findDevice(namespace: Namespace, device: DeviceId): Future[Seq[EcuInfoResponse]] = db.run {
     Schema.ecu
         .filter(_.namespace === namespace).filter(_.device === device)
-        .join(Schema.currentImage).on(_.ecuSerial === _.id)
+        .join(Schema.currentImage.filter(_.namespace === namespace)).on(_.ecuSerial === _.id)
         .map { case (ecu, curImage) => (ecu.ecuSerial, ecu.hardwareId, ecu.primary, curImage.filepath, curImage.length, curImage.checksum) }
         .result
         .failIfEmpty(MissingDevice)


### PR DESCRIPTION
Signed-off-by: Simão Mata <simao.mata@here.com>

before:
```
+------+-------------+-------+------+---------------+---------+---------+-------------+--------+-------------------------------------------------+
| id   | select_type | table | type | possible_keys | key     | key_len | ref         | rows   | Extra                                           |
+------+-------------+-------+------+---------------+---------+---------+-------------+--------+-------------------------------------------------+
|    1 | SIMPLE      | ecus  | ref  | PRIMARY       | PRIMARY | 710     | const,const |      1 | Using where                                     |
|    1 | SIMPLE      | x6    | ALL  | NULL          | NULL    | NULL    | NULL        | 870387 | Using where; Using join buffer (flat, BNL join) |
+------+-------------+-------+------+---------------+---------+---------+-------------+--------+-------------------------------------------------+
```


after

```
+------+-------------+----------------+--------+---------------+---------+---------+--------------------------------+------+-------------+
| id   | select_type | table          | type   | possible_keys | key     | key_len | ref                            | rows | Extra       |
+------+-------------+----------------+--------+---------------+---------+---------+--------------------------------+------+-------------+
|    1 | SIMPLE      | ecus           | ref    | PRIMARY       | PRIMARY | 710     | const,const                    |    1 | Using where |
|    1 | SIMPLE      | current_images | eq_ref | PRIMARY       | PRIMARY | 796     | const,director.ecus.ecu_serial |    1 | Using where |
+------+-------------+----------------+--------+---------------+---------+---------+--------------------------------+------+-------------+
```