### PR TITLE
Add new endpoint to return device debug information

### DIFF
--- a/src/main/resources/db/migration/V25__add_manifest_table.sql
+++ b/src/main/resources/db/migration/V25__add_manifest_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `device_manifests` (
+  `device_id` char(36) NOT NULL,
+  `success` BOOLEAN NOT NULL,
+  `payload` longtext NOT NULL,
+  `message` varchar(255) NOT NULL,
+  `received_at` DATETIME(3) NOT NULL,
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+  PRIMARY KEY (`device_id`, `success`),
+  INDEX `device_manifests_device_id` (`device_id`)
+) DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/src/main/scala/com/advancedtelematic/director/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Schema.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.model.Uri
 import cats.implicits._
 import com.advancedtelematic.director.data.DataType._
 import com.advancedtelematic.director.data.FileCacheRequestStatus.FileCacheRequestStatus
+import com.advancedtelematic.director.http.DeviceDebugInfo.ReceivedDeviceManifest
 import com.advancedtelematic.libats.data.DataType.HashMethod.HashMethod
 import com.advancedtelematic.libats.data.DataType.{Checksum, CorrelationId, HashMethod, Namespace, ValidChecksum}
 import com.advancedtelematic.libats.data.EcuIdentifier
@@ -205,4 +206,19 @@ object Schema {
       ((AutoUpdate.apply _).tupled, AutoUpdate.unapply)
   }
   protected [db] val autoUpdates = TableQuery[AutoUpdates]
+
+  class DeviceManifests(tag: Tag) extends Table[ReceivedDeviceManifest](tag, "device_manifests") {
+    def deviceId = column[DeviceId]("device_id")
+    def payload = column[Json]("payload")
+    def receivedAt = column[Instant]("received_at")
+    def success = column[Boolean]("success")
+    def message = column[String]("message")
+
+    def pk = primaryKey("device_manifest_pk", (deviceId, success))
+
+    override def * = (deviceId, payload, success, message, receivedAt) <>
+      ((ReceivedDeviceManifest.apply _).tupled, ReceivedDeviceManifest.unapply)
+  }
+
+  protected [db] val deviceManifests = TableQuery[DeviceManifests]
 }

--- a/src/main/scala/com/advancedtelematic/director/http/DeviceDebugInfo.scala
+++ b/src/main/scala/com/advancedtelematic/director/http/DeviceDebugInfo.scala
@@ -1,0 +1,55 @@
+package com.advancedtelematic.director.http
+
+import java.time.Instant
+
+import akka.http.scaladsl.server.{Directives, _}
+import com.advancedtelematic.director.data.AdminRequest.EcuInfoResponse
+import com.advancedtelematic.director.db.{AdminRepositorySupport, DeviceManifestsRepositorySupport, FileCacheRepositorySupport}
+import com.advancedtelematic.director.http.DeviceDebugInfo.{DeviceDebugResult, ReceivedDeviceManifest}
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object DeviceDebugInfo {
+  import com.advancedtelematic.libats.codecs.CirceCodecs._
+  import io.circe._
+  import io.circe.generic.semiauto._
+  import com.advancedtelematic.director.data.Codecs._
+
+  case class ReceivedDeviceManifest(deviceId: DeviceId, payload: Json, success: Boolean, msg: String, receivedAt: Instant)
+
+  case class DeviceDebugResult(deviceId: DeviceId, manifests: Seq[ReceivedDeviceManifest], targets: Seq[Json], ecus: Seq[EcuInfoResponse])
+
+  implicit val deviceManifestResponseEncoder: Encoder[ReceivedDeviceManifest] = deriveEncoder
+  implicit val deviceManifestResponseDecoder: Decoder[ReceivedDeviceManifest] = deriveDecoder
+
+  implicit val deviceDebugResultEncoder: Encoder[DeviceDebugResult] = deriveEncoder
+  implicit val deviceDebugResultDecoder: Decoder[DeviceDebugResult] = deriveDecoder
+}
+
+class DeviceDebugInfo extends FileCacheRepositorySupport with AdminRepositorySupport with DeviceManifestsRepositorySupport {
+    def find(deviceId: DeviceId)(implicit db: Database, ec: ExecutionContext): Future[DeviceDebugResult] = for {
+    ecus <- adminRepository.findDeviceById(deviceId)
+    targets <- fileCacheRepository.fetchDeviceTargets(deviceId)
+    manifests <- deviceManifestsRepository.findAll(deviceId)
+  } yield DeviceDebugResult(deviceId, manifests, targets, ecus)
+}
+
+
+class DeviceDebugInfoResource()(implicit db: Database, ec: ExecutionContext) {
+  import DeviceDebugInfo._
+  import Directives._
+  import com.advancedtelematic.libats.http.UUIDKeyAkka._
+  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+
+  val deviceDebug = new DeviceDebugInfo
+
+  def route: Route = {
+    pathPrefix("admin") {
+      (get & path("device" / DeviceId.Path)) { device =>
+        complete(deviceDebug.find(device))
+      }
+    }
+  }
+}

--- a/src/main/scala/com/advancedtelematic/director/http/DirectorRoutes.scala
+++ b/src/main/scala/com/advancedtelematic/director/http/DirectorRoutes.scala
@@ -6,15 +6,14 @@ import com.advancedtelematic.diff_service.http.DiffResource
 import com.advancedtelematic.director.VersionInfo
 import com.advancedtelematic.director.manifest.Verifier.Verifier
 import com.advancedtelematic.director.roles.Roles
-import com.advancedtelematic.libats.http.ErrorHandler
 import com.advancedtelematic.libats.http.DefaultRejectionHandler.rejectionHandler
+import com.advancedtelematic.libats.http.ErrorHandler
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
 import com.advancedtelematic.libtuf.data.TufDataType.TufKey
 import com.advancedtelematic.libtuf_server.keyserver.KeyserverClient
 import slick.jdbc.MySQLProfile.api._
 
 import scala.concurrent.ExecutionContext
-
 
 class DirectorRoutes(verifier: TufKey => Verifier,
                      keyserverClient: KeyserverClient,
@@ -36,7 +35,8 @@ class DirectorRoutes(verifier: TufKey => Verifier,
           new DeviceResource(extractNamespace, verifier, keyserverClient, roles).route ~
           new MultiTargetUpdatesResource(extractNamespace).route ~
           new DiffResource(extractNamespace, diffService).route
-        }
+        }~
+          new DeviceDebugInfoResource().route
       }
     }
 }

--- a/src/test/scala/com/advancedtelematic/director/http/DeviceDebugInfoInfoResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/DeviceDebugInfoInfoResourceSpec.scala
@@ -1,0 +1,64 @@
+package com.advancedtelematic.director.http
+
+import akka.http.scaladsl.model.StatusCodes
+import com.advancedtelematic.director.data.AdminRequest.{RegisterDevice, SetTarget}
+import com.advancedtelematic.director.data.KeyGenerators
+import com.advancedtelematic.director.db.{DeviceRepositorySupport, FileCacheDB, SetTargets}
+import com.advancedtelematic.director.util.{DefaultPatience, DirectorSpec, NamespaceTag, RouteResourceSpec}
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.libtuf.data.TufDataType
+import com.advancedtelematic.libtuf.data.TufDataType.SignatureMethod.SignatureMethod
+import org.scalatest.{BeforeAndAfterAll, Inspectors}
+import com.advancedtelematic.director.data.GeneratorOps._
+import com.advancedtelematic.libtuf.data.TufDataType.SignatureMethod
+import cats.syntax.show._
+import com.advancedtelematic.director.http.DeviceDebugInfo.DeviceDebugResult
+import DeviceDebugInfo._
+import com.advancedtelematic.director.util.NamespaceTag.NamespaceTag
+import com.advancedtelematic.libats.data.DataType.Namespace
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import com.advancedtelematic.libtuf.crypt.CanonicalJson._
+
+class DeviceDebugInfoInfoResourceSpec extends DirectorSpec with KeyGenerators with DefaultPatience with DeviceRepositorySupport
+  with FileCacheDB with RouteResourceSpec with NamespacedRequests with Inspectors with BeforeAndAfterAll {
+
+  override val testKeyType: TufDataType.KeyType = TufDataType.KeyType.default
+  override val testSignatureMethod: SignatureMethod = SignatureMethod.ED25519
+
+  testWithNamespace("returns device debug information") { implicit ns =>
+    createRepoOk(testKeyType)
+
+    val device = DeviceId.generate()
+    val primEcuReg = GenRegisterEcu.generate
+    val primEcu = primEcuReg.ecu_serial
+    val ecus = GenRegisterEcu.atMost(5).generate ++ (primEcuReg :: GenRegisterEcu.atMost(5).generate)
+
+    val regDev = RegisterDevice(device, primEcu, ecus)
+
+    registerDeviceOk(regDev)
+
+    val ecuManifests = ecus.map { regEcu => GenSignedEcuManifest(regEcu.ecu_serial).generate }
+
+    val deviceManifest = GenSignedDeviceManifest(primEcu, ecuManifests).generate
+
+    updateManifestOk(device, deviceManifest)
+    updateManifestOk(device, deviceManifest)
+
+    fetchTargetsFor(device)
+
+    Get(s"/admin/device/${device.show}") ~> routes ~> check  {
+      status shouldBe StatusCodes.OK
+
+      val deviceDebug = responseAs[DeviceDebugResult]
+
+      deviceDebug.deviceId shouldBe device
+      deviceDebug.ecus.map(_.id) should contain theSameElementsAs ecus.map(_.ecu_serial)
+
+      deviceDebug.manifests should have size(1)
+      deviceDebug.manifests.headOption.map(_.success) should contain(true)
+      deviceDebug.manifests.map(_.payload.canonical).headOption should contain(deviceManifest.json.canonical)
+
+      deviceDebug.targets shouldNot be(empty)
+    }
+  }
+}

--- a/src/test/scala/com/advancedtelematic/director/http/NamespacedRequests.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/NamespacedRequests.scala
@@ -68,7 +68,7 @@ trait NamespacedRequests extends DirectorSpec with DefaultPatience with RouteRes
     }
   }
 
-  def updateManifestExpect(device: DeviceId, manifest: SignedPayload[Json], expected: StatusCode)(implicit ns: NamespaceTag): Unit =
+  def updateManifestExpect(device: DeviceId, manifest: SignedPayload[Json], expected: StatusCode)(implicit ns: NamespaceTag, pos: Position): Unit =
     updateManifest(device, manifest) ~> routes ~> check {
       status shouldBe expected
     }


### PR DESCRIPTION
This is useful to get a quick overview of the information director has on a particular device.

It returns:
   - the last manifest uploaded by the device that was successfully processed by director

   - the last manifest uploaded by the device that was **not** successfully processed by director

   - all targets.json files generated for the device

   - all device ecus and metadata about ecus, that director knows about the device

Usage is /admin/device/:device_id