### PR TITLE
Add scans to CI/CD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,9 @@ stages:
   - test
   - build image
   - trigger deploy
+  - veracode scan
+  - deps scan
+  - pages
 
 variables:
   MYSQL_ROOT_PASSWORD: "root"
@@ -79,3 +82,45 @@ trigger sit deploy:
   trigger:
     project: OLP/EDGE/OTA/infra/deployment-descriptors
     branch: master
+
+deps scan:
+  # perform dependencies CVE analysis
+  stage: deps scan
+  only:
+    - schedules
+  image: advancedtelematic/gitlab-jobs:0.1.0
+  script:
+    - ./sbt dependencyCheckAggregate
+    - mv target/scala-*/dependency-check-report.html ./depchk.html
+  artifacts:
+    paths:
+      - depchk.html
+
+pages:
+  stage: pages
+  only:
+    - schedules
+  dependencies:
+    - deps scan
+  script:
+    - mkdir -p public
+    - mv depchk.html public/index.html
+  artifacts:
+    paths:
+      - public
+    expire_in: 64 days
+
+veracode scan:
+  # prepare and submit for static code analysis
+  stage: veracode scan
+  only:
+    variables:
+      - $VERACODE_API_ID
+  image: advancedtelematic/veracode:0.1.1
+  before_script:
+    - ./sbt package
+  script:
+    - run-veracode.sh
+  artifacts:
+    paths:
+      - /tmp/package.zip


### PR DESCRIPTION
The veracode pipeline is intended to be run as part of schedule only.
Test run: https://main.gitlab.in.here.com/olp/edge/ota/connect/back-end/director/pipelines/132037
Generated report: https://olp.pages.gitlab.in.here.com/edge/ota/connect/back-end/director/