### PR TITLE
Increase akka connection pool size

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -17,10 +17,21 @@ ats {
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   loglevel = "DEBUG"
+  loglevel = ${?AKKA_LOGLEVEL}
 
   http.host-connection-pool {
-    max-connections = 8
-    max-open-requests = 64
+    # The maximum number of parallel connections that a connection pool to a
+    # single host endpoint is allowed to establish. Must be greater than zero.
+    max-connections = 2048
+    max-connections = ${?AKKA_HTTP_MAX_CONNECTIONS}
+    # The maximum number of open requests accepted into the pool across all
+    # materializations of any of its client flows.
+    # Protects against (accidentally) overloading a single pool with too many client flow materializations.
+    # Note that with N concurrent materializations the max number of open request in the pool
+    # will never exceed N * max-connections * pipelining-limit.
+    # Must be a power of 2 and > 0!
+    max-open-requests = 8192
+    max-open-requests = ${?AKKA_HTTP_MAX_OPEN_REQUESTS}
   }
 }
 
@@ -41,7 +52,8 @@ database = {
     password = ${?DB_PASSWORD}
     rewriteBatchedStatements=true
   }
-  numThreads = 10
+  numThreads = 20
+  numThreads = ${?DB_NUM_THREADS}
   migrate = false
   migrate = ${?DB_MIGRATE}
   registerMbeans = true


### PR DESCRIPTION
During two P2 incedents we noticed that director was using a very low
cpu ammount even though each pod was assigned with a large cpu limit.

We noticed that slick db queues were increasing but db connections
were still being handled and not dropped.

We noticed that the akka pool was set to only 8 connections maximum,
which is not enough to handle many connections and explains the low
cpu usage even though there is a high cpu limit.

This commit increases the akka pool limits to handle more connections
at the same time.

the number of threads for the db is also doubled as to reduce the
slick queue size, even though we don't that is the limiting factor.

Signed-off-by: Simão Mata <simao.mata@here.com>