### PR TITLE
Scala migration for director1.filecache to director2.signed_roles

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/db/SignedRoleMigration.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/SignedRoleMigration.scala
@@ -1,0 +1,77 @@
+package com.advancedtelematic.director.db
+
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+
+import akka.http.scaladsl.util.FastFuture
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Sink, Source}
+import akka.{Done, NotUsed}
+import com.advancedtelematic.libats.codecs.CirceCodecs.checkSumEncoder
+import com.advancedtelematic.libats.data.DataType.Checksum
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.libtuf.crypt.CanonicalJson._
+import com.advancedtelematic.libtuf.data.TufDataType.RoleType
+import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
+import com.advancedtelematic.libtuf_server.crypto.Sha256Digest
+import io.circe.syntax._
+import slick.jdbc.GetResult._
+import slick.jdbc.MySQLProfile.api._
+import slick.jdbc.{GetResult, PositionedParameters, SetParameter}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+// migrate director.file_cache to director2.signed_roles
+// (director2.checksum can only be created in Scala.)
+class SignedRoleMigration(old_director_schema: String = "director")
+                         (implicit val db: Database, val mat: Materializer, val ec: ExecutionContext) {
+
+  implicit val getRoleTypeResult = GetResult(r => RoleType.withName(r.nextString()))
+  implicit val setRoleTypeParameter: SetParameter[RoleType] =
+    (roleType: RoleType, pp: PositionedParameters) => pp.setString(roleType.toString)
+
+  implicit val getDeviceIdResult = GetResult(r => DeviceId(UUID.fromString(r.nextString)))
+  implicit val setDeviceIdParameter: SetParameter[DeviceId] =
+    (deviceId: DeviceId, pp: PositionedParameters) => pp.setString(deviceId.uuid.toString)
+
+  implicit val getInstantResult = GetResult(r => r.nextTimestamp().toInstant)
+  implicit val setInstantParameter: SetParameter[Instant] =
+    (instant: Instant, pp: PositionedParameters) => pp.setTimestamp(Timestamp.from(instant))
+
+  implicit val setChecksumParameter: SetParameter[Checksum] =
+    (checksum: Checksum, pp: PositionedParameters) => pp.setString(checksum.asJson.noSpaces)
+
+  def exists(schema: String, table: String): Future[Boolean] = {
+    val sql = sql"SELECT EXISTS(SELECT * FROM information_schema.tables WHERE table_schema = $schema AND table_name = $table)"
+                      .as[Boolean]
+    db.run(sql).map(_.head)
+  }
+
+  def fileCache: Source[(RoleType, Int, DeviceId, String, Instant, Instant, Instant), NotUsed] = {
+    val sql = sql""" select role,version,device,file_entity,created_at,updated_at,expires from #$old_director_schema.file_cache """
+                                              .as[(RoleType,Int,DeviceId,String,Instant,Instant,Instant)]
+    Source.fromPublisher(db.stream(sql))
+  }
+
+  def writeSignedRole(role: RoleType, version: Int, deviceId: DeviceId, content: String, createdAt: Instant, updatedAt: Instant, expiresAt: Instant): Future[String] = {
+    val canonicalJson = content.asJson.canonical
+    val checksum = Sha256Digest.digest(canonicalJson.getBytes)
+    val length = canonicalJson.length
+    val sql =
+      sqlu"""insert into signed_roles value ($role,$version,$deviceId,$checksum,$length,$content,$createdAt,$updatedAt,$expiresAt)
+        on duplicate key update checksum=$checksum,length=$length,content=$content,created_at=$createdAt,updated_at=$updatedAt,expires_at=$expiresAt
+          """
+    db.run(sql).map(_ => content)
+  }
+
+  def run: Future[Done] = {
+    exists(old_director_schema, "file_cache").flatMap { flag =>
+      if (flag)
+        fileCache.mapAsync(1)((writeSignedRole _).tupled).runWith(Sink.ignore)
+      else
+        FastFuture.successful(Done)
+    }
+  }
+
+}

--- a/src/main/scala/db/migration/R__MigrateSignedRoles.scala
+++ b/src/main/scala/db/migration/R__MigrateSignedRoles.scala
@@ -1,0 +1,20 @@
+package db.migration
+
+import java.security.Security
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.advancedtelematic.director.db.SignedRoleMigration
+import com.advancedtelematic.libats.slick.db.AppMigration
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import slick.jdbc.MySQLProfile.api._
+
+class R__MigrateSignedRoles extends AppMigration  {
+  Security.addProvider(new BouncyCastleProvider)
+
+  implicit val system = ActorSystem(this.getClass.getSimpleName)
+  implicit val materializer = ActorMaterializer()
+  import system.dispatcher
+
+  override def migrate(implicit db: Database) = new SignedRoleMigration().run.map(_ => ())
+}

--- a/src/test/resources/db/migration/V1001__migration_test.sql
+++ b/src/test/resources/db/migration/V1001__migration_test.sql
@@ -1,0 +1,16 @@
+drop database if exists director1_test;
+create database director1_test default character set utf8 default collate utf8_bin;
+
+CREATE TABLE director1_test.file_cache (
+          `role` enum('ROOT','SNAPSHOT','TARGETS','TIMESTAMP') COLLATE utf8_unicode_ci NOT NULL,
+          `version` int(11) NOT NULL,
+          `device` char(36) COLLATE utf8_unicode_ci NOT NULL,
+          `file_entity` longtext COLLATE utf8_unicode_ci NOT NULL,
+          `created_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+          `updated_at` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+          `expires` datetime(3) NOT NULL,
+          PRIMARY KEY (`role`,`version`,`device`));
+
+insert into director1_test.file_cache values ('SNAPSHOT', 0, '00000095-1454-40a5-b54e-caeb117f7aab',
+    '{"signatures":[{"keyid":"be7b4b5b36f1e8ab0e5e211d3f781bdfd7eeafd5351942b239090aeccf0e65cc","method":"rsassa-pss-sha256","sig":"Y1+Oqx/ORmO/Ru384w4DoP2GDkdPv92h12yyDAaQjknIFtVV+1MRacVdG6axJYsG4nffcWqf7yWN6HJWfflIwxfhaK6mdLXU621jed+vQb7pdsdrzdVaKaN0mcxj1ICRhzsErfBI3HIOUX1E4FhYtB7fKURqXjWtqKgYSXA7X+Hr+RM+bPaIuzvWg5jh8vrqB8EnCQNXoXiy9Rsuk5jtU21JgyXiQOTfsEAxy6D8XJ8ebgXW1q0izpLNJqOuMQk/1mkvjfzY9+qBgYuKdUTLjcglMpxzRjfJIx8C2OUxG6C8WrqbS9lNkBKbEeVpcmw5AOPT24PELww7ndM3+6JnkA=="}],"signed":{"_type":"Snapshot","meta":{"targets.json":{"hashes":{"sha256":"11f31e74802087786cc44ff2b320a6c6d2172e952afae7b45d00fcc0a62919ae"},"length":562,"version":0}},"expires":"2019-12-24T03:15:58Z","version":0}}',
+    '2019-11-23 03:15:58.687', '2019-11-23 03:15:58.687', '2019-12-24 03:15:58.542');

--- a/src/test/scala/com/advancedtelematic/director/db/SignedRoleMigrationSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/db/SignedRoleMigrationSpec.scala
@@ -1,0 +1,37 @@
+package com.advancedtelematic.director.db
+
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.libats.test.DatabaseSpec
+import com.advancedtelematic.libtuf.data.ClientDataType.SnapshotRole
+import org.scalatest.AsyncFunSuite
+
+import scala.async.Async.{async, await}
+import scala.concurrent.ExecutionContext
+
+class SignedRoleMigrationSpec extends AsyncFunSuite with DatabaseSpec {
+
+  implicit val system: ActorSystem = ActorSystem(this.getClass.getSimpleName)
+
+  implicit val mat = ActorMaterializer()
+
+  implicit val ec = ExecutionContext.Implicits.global
+
+  val subject = new SignedRoleMigration("director1_test")
+
+  val dbSignedRoleRepository = new DbSignedRoleRepository()
+
+  test("signed roles are migrated") {
+    val deviceId = DeviceId(UUID.fromString("00000095-1454-40a5-b54e-caeb117f7aab"))
+
+    async {
+      await(subject.run)
+      val signedRole = await(dbSignedRoleRepository.findLatest[SnapshotRole](deviceId))
+      assert(signedRole.device == deviceId)
+    }
+  }
+
+}


### PR DESCRIPTION
Only running migration if director.file_cache is there. Something similar should probably be implemented for https://github.com/advancedtelematic/director/pull/190 as well.

Signed-off-by: Jochen Schneider <j.schneider@here.com>