### PR TITLE
Adjust server max-connections

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -18,20 +18,29 @@ akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   loglevel = "DEBUG"
   loglevel = ${?AKKA_LOGLEVEL}
+  log-config-on-start = off
+  log-config-on-start = ${?AKKA_LOG_CONFIG_ON_START}
 
-  http.host-connection-pool {
-    # The maximum number of parallel connections that a connection pool to a
-    # single host endpoint is allowed to establish. Must be greater than zero.
-    max-connections = 2048
-    max-connections = ${?AKKA_HTTP_MAX_CONNECTIONS}
-    # The maximum number of open requests accepted into the pool across all
-    # materializations of any of its client flows.
-    # Protects against (accidentally) overloading a single pool with too many client flow materializations.
-    # Note that with N concurrent materializations the max number of open request in the pool
-    # will never exceed N * max-connections * pipelining-limit.
-    # Must be a power of 2 and > 0!
-    max-open-requests = 8192
-    max-open-requests = ${?AKKA_HTTP_MAX_OPEN_REQUESTS}
+  http {
+    server {
+      max-connections = 2048
+      max-connections = ${?AKKA_HTTP_MAX_CONNECTIONS}
+    }
+
+    host-connection-pool {
+      # The maximum number of parallel connections that a connection pool to a
+      # single host endpoint is allowed to establish. Must be greater than zero.
+      max-connections = 2048
+      max-connections = ${?AKKA_HTTP_CLIENT_MAX_CONNECTIONS}
+      # The maximum number of open requests accepted into the pool across all
+      # materializations of any of its client flows.
+      # Protects against (accidentally) overloading a single pool with too many client flow materializations.
+      # Note that with N concurrent materializations the max number of open request in the pool
+      # will never exceed N * max-connections * pipelining-limit.
+      # Must be a power of 2 and > 0!
+      max-open-requests = 4096
+      max-open-requests = ${?AKKA_HTTP_CLIENT_MAX_OPEN_REQUESTS}
+    }
   }
 }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -63,6 +63,8 @@ database = {
   }
   numThreads = 20
   numThreads = ${?DB_NUM_THREADS}
+  queueSize = 1000
+  queueSize = ${?DB_QUEUE_SIZE}
   migrate = false
   migrate = ${?DB_MIGRATE}
   registerMbeans = true


### PR DESCRIPTION
In https://github.com/advancedtelematic/director/pull/191 we increased
the akka http client max connections. This solve the problem when
contacting director, but it did not increase the number of max
connections the akka server actually supports.

This was due to a mixing `server` key in the configuration.