### PR TITLE
Skip tests on ci deploy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,9 @@ test:
   tags:
     - docker-sock
   image: advancedtelematic/gitlab-jobs:0.2.3
+  except:
+    refs:
+      - deploy/sit
   variables:
     DB_URL: "jdbc:mariadb://db:3306/$MYSQL_DATABASE"
   before_script:


### PR DESCRIPTION
To have an image deploy, tests must have been executed already.

Same as https://github.com/advancedtelematic/ota-device-registry/pull/138