### PR TITLE
Always bump version when refreshing metadata

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Schema.scala
@@ -132,6 +132,8 @@ object Schema {
     def device  = column[DeviceId]("device")
     def fileEntity = column[Json]("file_entity")
     def expires = column[Instant]("expires")
+    def createdAt = column[Instant]("created_at")
+    def updatedAt = column[Instant]("updated_at")
 
     def primKey = primaryKey("file_cache_pk", (role, version, device))
 

--- a/src/test/scala/com/advancedtelematic/director/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/director/data/Generators.scala
@@ -71,7 +71,7 @@ trait Generators {
     tf <- Gen.option(GenTargetFormat)
     nr <- Gen.posNum[Int]
     uri <- Gen.option(Gen.const(Uri(s"http://test-$nr.example.com")))
-  } yield CustomImage(im, uri, tf)
+  } yield CustomImage(im, uri, None)
 
   lazy val GenChecksum: Gen[Checksum] = for {
     hash <- GenRefinedStringByCharN[ValidChecksum](64, GenHexChar)

--- a/src/test/scala/com/advancedtelematic/director/db/FileCacheDB.scala
+++ b/src/test/scala/com/advancedtelematic/director/db/FileCacheDB.scala
@@ -1,35 +1,31 @@
 package com.advancedtelematic.director.db
 
-import akka.Done
-import com.advancedtelematic.director.data.FileCacheRequestStatus
-import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
-import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
-import com.advancedtelematic.libats.slick.db.SlickExtensions._
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import scala.concurrent.{ExecutionContext, Future}
-import slick.jdbc.MySQLProfile.api._
-import SlickMapping._
 
-trait FileCacheDB {
-  def makeFilesExpire(device: DeviceId)
-                     (implicit db: Database, ec: ExecutionContext): Future[Done] = db.run {
+import akka.Done
+import com.advancedtelematic.director.util.NamespaceTag.NamespaceTag
+import com.advancedtelematic.director.util.RouteResourceSpec
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.libats.slick.db.SlickExtensions._
+import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.Future
+
+trait FileCacheDB extends FileCacheRequestRepositorySupport {
+  self: RouteResourceSpec =>
+
+  def makeFilesExpire(device: DeviceId): Future[Done] = db.run {
     Schema.fileCache
       .filter(_.device === device)
       .map(_.expires)
       .update(Instant.now.minus(10, ChronoUnit.DAYS))
   }.map(_ => Done)
 
-  def pretendToGenerate()(implicit db: Database, ec: ExecutionContext): Future[Done] = db.run {
-    for {
-      fcrs <- Schema.fileCacheRequest
-        .filter(_.status === FileCacheRequestStatus.PENDING)
-        .result
-      _ <- Schema.fileCacheRequest
-        .filter(_.device.inSet(fcrs.map(_.device).toSet))
-        .filter(_.timestampVersion.inSet(fcrs.map(_.timestampVersion).toSet))
-        .map(_.status)
-        .update(FileCacheRequestStatus.SUCCESS)
-    } yield Done
-  }
+  def generateAllPendingFiles(deviceId: Option[DeviceId] = None)(implicit ns: NamespaceTag): Future[Unit] = for {
+    allPending <- fileCacheRequestRepository.findPending(limit = Int.MaxValue)
+    devicePending = allPending.filter(p => deviceId.isEmpty || deviceId.contains(p.device)).filter(p => p.namespace == ns.get)
+    _ <- Future.traverse(devicePending){fcr => rolesGeneration.processFileCacheRequest(fcr)}
+  } yield ()
 }

--- a/src/test/scala/com/advancedtelematic/director/http/AssignmentsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/AssignmentsResourceSpec.scala
@@ -2,16 +2,17 @@ package com.advancedtelematic.director.http
 
 import akka.http.scaladsl.model.StatusCodes
 import cats.syntax.show._
-import com.advancedtelematic.director.data.Codecs.{targetsCustomDecoder, assignUpdateRequestEncoder}
+import com.advancedtelematic.director.data.Codecs.{assignUpdateRequestEncoder, targetsCustomDecoder}
 import com.advancedtelematic.director.data.DataType.TargetsCustom
 import com.advancedtelematic.director.data.AdminRequest.AssignUpdateRequest
 import com.advancedtelematic.director.data.{EdGenerators, RsaGenerators}
+import com.advancedtelematic.director.db.FileCacheDB
 import com.advancedtelematic.director.util.NamespaceTag._
 import com.advancedtelematic.libats.data.DataType.{CampaignId, MultiTargetUpdateId}
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 
-trait AssignmentsResourceSpec extends DeviceUpdateSpec {
+trait AssignmentsResourceSpec extends DeviceUpdateSpec with FileCacheDB {
 
   def createDeviceWithAssignment()(implicit ns: NamespaceTag) = {
     createRepo().futureValue

--- a/src/test/scala/com/advancedtelematic/director/http/AutoUpdateSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/AutoUpdateSpec.scala
@@ -121,6 +121,7 @@ trait AutoUpdateSpec extends DirectorSpec with KeyGenerators with FileCacheDB wi
   }
 
   testWithNamespace("when TufTargetEvent fires, updates gets scheduled") { implicit ns =>
+    createRepo
     val (device1, primEcu1, ecus1) = regDevice(hw0)
     val (device2, primEcu2, ecus2) = regDevice(hw0)
     val (deviceN, primEcuN, ecusN) = regDevice(hw0)
@@ -131,7 +132,7 @@ trait AutoUpdateSpec extends DirectorSpec with KeyGenerators with FileCacheDB wi
     setAutoUpdate(device2, primEcu2, targetName)
 
     tufTargetWorker.action(tufTargetAdded).futureValue
-    pretendToGenerate().futureValue
+    generateAllPendingFiles().futureValue
 
     def checkQueue(device: DeviceId, primEcu: EcuIdentifier): Unit = {
       val queue = deviceQueueOk(device)
@@ -153,6 +154,7 @@ trait AutoUpdateSpec extends DirectorSpec with KeyGenerators with FileCacheDB wi
   }
 
   testWithNamespace("TufTargetEvent schedule for device with multiple matching ecus") { implicit ns =>
+    createRepo
     val (device, primEcu, Seq(ecu0, ecu1)) = regDevice(hw0, hw1, hw1)
 
     val (tufTargetAdded, targetName) = generateTufTargetAdded(hw1)
@@ -161,7 +163,7 @@ trait AutoUpdateSpec extends DirectorSpec with KeyGenerators with FileCacheDB wi
     setAutoUpdate(device, ecu1, targetName)
 
     tufTargetWorker.action(tufTargetAdded).futureValue
-    pretendToGenerate().futureValue
+    generateAllPendingFiles().futureValue
 
     val queue = deviceQueueOk(device)
 

--- a/src/test/scala/com/advancedtelematic/director/http/DeviceUpdateSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/DeviceUpdateSpec.scala
@@ -56,11 +56,6 @@ trait DeviceUpdateSpec extends DirectorSpec
     createMultiTargetUpdateOK(mtu)
   }
 
-  def generateAllPendingFiles(): Future[Unit] = for {
-    pends <- fileCacheRequestRepository.findPending()
-    _ <- Future.traverse(pends){fcr => rolesGeneration.processFileCacheRequest(fcr)}
-  } yield ()
-
   def createRepo()(implicit ns: NamespaceTag): Future[Unit] = {
     val repoId = RepoId.generate
     for {

--- a/src/test/scala/com/advancedtelematic/director/http/DiffSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/DiffSpec.scala
@@ -5,11 +5,12 @@ import com.advancedtelematic.director.data.Codecs.decoderTargetCustom
 import com.advancedtelematic.director.data.DataType.TargetCustom
 import com.advancedtelematic.director.data.GeneratorOps._
 import com.advancedtelematic.director.data.{EdGenerators, RsaGenerators}
+import com.advancedtelematic.director.db.FileCacheDB
 import com.advancedtelematic.libats.data.RefinedUtils._
 import com.advancedtelematic.libtuf.data.TufDataType.ValidTargetFilename
 import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat.OSTREE
 
-trait DiffSpec extends DeviceUpdateSpec {
+trait DiffSpec extends DeviceUpdateSpec with FileCacheDB {
 
   testWithNamespace("device waits for diff") { implicit ns =>
     createRepo().futureValue

--- a/src/test/scala/com/advancedtelematic/director/http/FileCacheSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/FileCacheSpec.scala
@@ -203,7 +203,8 @@ trait FileCacheSpec extends DirectorSpec
 
     val oldTime = isAvailable[TimestampRole](device, "timestamp.json").signed.expires
     isAvailable[SnapshotRole](device, "snapshot.json").signed.expires shouldBe oldTime
-    isAvailable[TargetsRole](device, "targets.json").signed.expires shouldBe oldTime
+    val oldTargets = isAvailable[TargetsRole](device, "targets.json")
+    oldTargets.signed.expires shouldBe oldTime
     isAvailable[RootRole](device, "root.json")
 
     makeFilesExpire(device).futureValue
@@ -213,7 +214,10 @@ trait FileCacheSpec extends DirectorSpec
     val newTime = isAvailable[TimestampRole](device, "timestamp.json").signed.expires
     newTime should beAfter(oldTime)
     isAvailable[SnapshotRole](device, "snapshot.json").signed.expires shouldBe newTime
-    isAvailable[TargetsRole](device, "targets.json").signed.expires shouldBe newTime
+
+    val newTargets = isAvailable[TargetsRole](device, "targets.json")
+    newTargets.signed.expires shouldBe newTime
+    newTargets.signed.version shouldBe oldTargets.signed.version + 1
   }
 }
 


### PR DESCRIPTION
In some cases the metadata version is not bumped when refreshing a role expiration date.

For example:

1. device is at `current_target` 5
2. device downloads targets version 6 with new update (`current_target` remains at 5) 
3. metadata expires before device installs it
4. device requests targets.json again, but is provided version 6 again with a different expire date. This happens because the version is calculated based on the version the device has installed (`current_target`), rather than the version the device actually downloaded last (`current_target + 1`).

This PR makes director calculate the version bump based on the last generated metadata (`file_cache` table), rather than the version that was used to install the last update (`device_current_targets` table)

Additionally, when the device finally pushes a manifest, the version is bumped to the last generated targets.json, rather than `current_target`. This is not strictly necessary since the version used to generate metadata would now be in `file_cache`, but it would mean the versions of `current_target` and `file_cache` would never match again.