### PR TITLE
Take latest generated role into account for device assignments

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Repository.scala
@@ -330,7 +330,6 @@ protected class FileCacheRepository()(implicit db: Database, ec: ExecutionContex
     Schema.fileCache
       .filter(_.device === deviceId)
       .map(_.version)
-      .sortBy(_.desc)
       .max
       .result
   }

--- a/src/main/scala/com/advancedtelematic/director/db/SetTargets.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/SetTargets.scala
@@ -12,13 +12,14 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object SetTargets extends DeviceUpdateAssignmentRepositorySupport
     with EcuUpdateAssignmentRepositorySupport
+    with FileCacheRepositorySupport
     with FileCacheRequestRepositorySupport {
 
   protected [db] def setDeviceTargetAction(namespace: Namespace, device: DeviceId, updateId: Option[UpdateId],
                                            targets: Map[EcuIdentifier, CustomImage],
                                            correlationId: Option[CorrelationId] = None)
                                           (implicit db: Database, ec: ExecutionContext): DBIO[Int] = for {
-    new_version <- deviceUpdateAssignmentRepository.persistAction(namespace, device, correlationId, updateId)
+    new_version <- deviceUpdateAssignmentRepository.persistAction(namespace, device, correlationId, updateId)(fileCacheRepository)
     _ <- ecuUpdateAssignmentRepository.persistAction(namespace, device, new_version, targets)
     fcr = FileCacheRequest(namespace, new_version, device,
                            FileCacheRequestStatus.PENDING, new_version, correlationId)

--- a/src/main/scala/com/advancedtelematic/director/roles/Roles.scala
+++ b/src/main/scala/com/advancedtelematic/director/roles/Roles.scala
@@ -1,6 +1,5 @@
 package com.advancedtelematic.director.roles
 
-import akka.Done
 import akka.http.scaladsl.util.FastFuture
 import com.advancedtelematic.director.data.DataType.FileCacheRequest
 import com.advancedtelematic.director.data.FileCacheRequestStatus
@@ -14,7 +13,7 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.MySQLProfile.api._
-
+import cats.syntax.option._
 import scala.async.Async._
 
 class Roles(rolesGeneration: RolesGeneration)
@@ -37,7 +36,7 @@ class Roles(rolesGeneration: RolesGeneration)
     shouldBeRegenerated(ns, device, version).flatMap {
       case true =>
         val fcr = FileCacheRequest(ns, version + 1, device, FileCacheRequestStatus.PENDING, version + 1)
-        rolesGeneration.processFileCacheRequest(fcr).map(_ => version + 1)
+        rolesGeneration.processFileCacheRequest(fcr, assignmentsVersion = version.some).map(_ => version + 1)
       case false =>
         FastFuture.successful(version)
     }.recoverWith {

--- a/src/main/scala/com/advancedtelematic/director/roles/RolesGeneration.scala
+++ b/src/main/scala/com/advancedtelematic/director/roles/RolesGeneration.scala
@@ -123,15 +123,19 @@ class RolesGeneration(tuf: KeyserverClient, diffService: DiffServiceClient)
   }
 
   private def tryToGenerate(namespace: Namespace, device: DeviceId, targetVersion: Int, timestampVersion: Int,
-    correlationId: Option[CorrelationId]): Future[Done] = for {
-    targets <- adminRepository.fetchCustomTargetVersion(namespace, device, targetVersion)
+    correlationId: Option[CorrelationId], assignmentsVersion: Int): Future[Done] = for {
+    targets <- adminRepository.fetchCustomTargetVersion(namespace, device, assignmentsVersion)
     currentImages <- adminRepository.findImages(namespace, device)
     customTargets <- generateCustomTargets(namespace, device, currentImages.toMap, targets)
     _ <- generateWithCustom(namespace, device, targetVersion, timestampVersion, customTargets,
                             correlationId.map(c => TargetsCustom(Some(c))))
   } yield Done
 
-  def processFileCacheRequest(fcr: FileCacheRequest): Future[Unit] = for {
-    _ <- tryToGenerate(fcr.namespace, fcr.device, fcr.targetVersion, fcr.timestampVersion, fcr.correlationId)
+  /*
+     Generates a targets.json with a devices current assignment (assignmentsVersion),
+      which can be different from the version in targets.json (targetVersion)
+     */
+  def processFileCacheRequest(fcr: FileCacheRequest, assignmentsVersion: Option[Int] = None): Future[Unit] = for {
+    _ <- tryToGenerate(fcr.namespace, fcr.device, fcr.targetVersion, fcr.timestampVersion, fcr.correlationId, assignmentsVersion.getOrElse(fcr.targetVersion))
   } yield ()
 }

--- a/src/main/scala/com/advancedtelematic/director/roles/RolesGeneration.scala
+++ b/src/main/scala/com/advancedtelematic/director/roles/RolesGeneration.scala
@@ -91,7 +91,7 @@ class RolesGeneration(tuf: KeyserverClient, diffService: DiffServiceClient)
                                  custom: Option[TargetsCustom]): Future[Done] = for {
     repo <- repoNameRepository.getRepo(namespace)
 
-    expires = Instant.now.plus(31, ChronoUnit.DAYS)
+    expires = Instant.now.plus(6 * 31, ChronoUnit.DAYS)
     targetsRole   <- signRole(repo, RoleType.TARGETS, targetsRole(targets, targetVersion, expires, custom))
     snapshotRole  <- signRole(repo, RoleType.SNAPSHOT, snapshotRole(targetsRole, targetVersion, expires))
     timestampRole <- signRole(repo, RoleType.TIMESTAMP, timestampRole(snapshotRole, timestampVersion, expires))

--- a/src/test/scala/com/advancedtelematic/director/http/FileCacheSpec.scala
+++ b/src/test/scala/com/advancedtelematic/director/http/FileCacheSpec.scala
@@ -218,6 +218,8 @@ trait FileCacheSpec extends DirectorSpec
     val newTargets = isAvailable[TargetsRole](device, "targets.json")
     newTargets.signed.expires shouldBe newTime
     newTargets.signed.version shouldBe oldTargets.signed.version + 1
+    newTargets.signed.targets shouldNot be(empty)
+    newTargets.signed.targets shouldBe oldTargets.signed.targets
   }
 }
 


### PR DESCRIPTION
Take latest generated role into account every time current assignment
is calculated.

This is a follow up to
https://github.com/advancedtelematic/director/pull/198

Without this change, targets are renewed and version is bumped, but
the targets could be empty in some cases.

This is another consequence of using the role version to determine
which software the device is running, this means we need to always
check which version is higher, the one used for assignments or the one
used to generate roles, and use the assignment version to generate a
new role vversion.

Signed-off-by: Simão Mata <simao.mata@here.com>