### PR TITLE
Use role when querying file_cache

### DIFF
--- a/src/main/resources/db/migration/V27__add_file_cache_index.sql
+++ b/src/main/resources/db/migration/V27__add_file_cache_index.sql
@@ -1,0 +1,1 @@
+create index file_cache_device_idx on file_cache (`device`);


### PR DESCRIPTION
To force mysql to use PK index

Signed-off-by: Simão Mata <simao.mata@here.com>