### PR TITLE
Force targets regeneration if devices got wrong targets

### DIFF
--- a/src/main/scala/com/advancedtelematic/director/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/director/db/Repository.scala
@@ -341,7 +341,7 @@ protected class FileCacheRepository()(implicit db: Database, ec: ExecutionContex
       .result
       .headOption.map {
       case Some((createdAt, updatedAt)) => updatedAt.minusSeconds(5).isAfter(createdAt)
-       case None => false
+      case None => false
     }
   }
 

--- a/src/main/scala/com/advancedtelematic/director/roles/Roles.scala
+++ b/src/main/scala/com/advancedtelematic/director/roles/Roles.scala
@@ -1,11 +1,11 @@
 package com.advancedtelematic.director.roles
 
 import akka.http.scaladsl.util.FastFuture
-import com.advancedtelematic.director.data.DataType.FileCacheRequest
+import com.advancedtelematic.director.data.DataType.{DeviceUpdateAssignment, FileCacheRequest}
 import com.advancedtelematic.director.data.FileCacheRequestStatus
 import com.advancedtelematic.director.db.{DeviceRepositorySupport, DeviceUpdateAssignmentRepositorySupport, FileCacheRepositorySupport, FileCacheRequestRepositorySupport, MultiTargetUpdatesRepositorySupport, Errors => DBErrors}
 import com.advancedtelematic.director.roles.RolesGeneration.MtuDiffDataMissing
-import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.data.DataType.{CorrelationId, Namespace}
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType
 import io.circe.Json
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.MySQLProfile.api._
-import cats.syntax.option._
+
 import scala.async.Async._
 
 class Roles(rolesGeneration: RolesGeneration)
@@ -26,25 +26,40 @@ class Roles(rolesGeneration: RolesGeneration)
 
   private lazy val _log = LoggerFactory.getLogger(this.getClass)
 
-  private def shouldBeRegenerated(ns: Namespace, device: DeviceId, version: Int): Future[Boolean] = async {
-    val expired = await(fileCacheRepository.haveExpired(device, version))
-    val wasUpdated = await(fileCacheRepository.roleWasUpdated(device, version, RoleType.TARGETS))
-    expired || wasUpdated
+  /*
+  Due to https://saeljira.it.here.com/browse/OTA-4539 some devices downloaded targets.json without a correlationId,
+  so we need to check if they need a new targets.json with the same targets but with correlation id added.
+
+  This method gets the latest targets.json from the database and checks whether it should have a correlationId but doesn't.
+  This will trigger a new targets.json generation if the correlation is missing
+   */
+  private def correlationIdMissing(json: Json, correlationId: Option[CorrelationId]): Boolean = {
+    val targetsCorrelationMissing = json.hcursor.downField("signed").downField("custom").downField("correlationId").failed
+    _log.debug(s"correlationId=$correlationId,correlationIdMissing=$targetsCorrelationMissing")
+    correlationId.isDefined && targetsCorrelationMissing
   }
 
-  private def updateCacheIfExpired(ns: Namespace, device: DeviceId, version: Int): Future[Int] = async {
-    val assignment = await(deviceUpdateAssignmentRepository.find(ns, device, version))
-    val regenerate = await(shouldBeRegenerated(ns, device, version))
+  private def shouldBeRegenerated(ns: Namespace, device: DeviceId, version: Int, correlationId: Option[CorrelationId]): Future[Boolean] = async {
+    val isExpired = await(fileCacheRepository.haveExpired(device, version))
+    val wasUpdated = await(fileCacheRepository.roleWasUpdated(device, version, RoleType.TARGETS))
+    val lastTargets = await(fileCacheRepository.fetchTarget(device, version))
+    isExpired || wasUpdated || correlationIdMissing(lastTargets, correlationId)
+  }
+
+  private def updateCacheIfExpired(ns: Namespace, device: DeviceId, latestTargetsVersion: Int, assignment: Option[DeviceUpdateAssignment]): Future[Int] = async {
+    val correlationId = assignment.flatMap(_.correlationId)
+    val regenerate = await(shouldBeRegenerated(ns, device, latestTargetsVersion, correlationId))
 
     if(regenerate) await {
-      val fcr = FileCacheRequest(ns, version + 1, device, FileCacheRequestStatus.PENDING, version + 1, correlationId = assignment.flatMap(_.correlationId))
-      rolesGeneration.processFileCacheRequest(fcr, assignmentsVersion = version.some).map(_ => version + 1)
+      val nextVersion = latestTargetsVersion + 1
+      val fcr = FileCacheRequest(ns, nextVersion, device, FileCacheRequestStatus.PENDING, nextVersion, correlationId = correlationId)
+      rolesGeneration.processFileCacheRequest(fcr, assignmentsVersion = assignment.map(_.version)).map(_ => nextVersion)
     } else
-      version
+      latestTargetsVersion
   }.recoverWith {
     case DBErrors.NoCacheEntry =>
-      val fcr = FileCacheRequest(ns, version, device, FileCacheRequestStatus.PENDING, version)
-      rolesGeneration.processFileCacheRequest(fcr).map(_ => version)
+      val fcr = FileCacheRequest(ns, latestTargetsVersion, device, FileCacheRequestStatus.PENDING, latestTargetsVersion, assignment.flatMap(_.correlationId))
+      rolesGeneration.processFileCacheRequest(fcr, assignmentsVersion = assignment.map(_.version)).map(_ => latestTargetsVersion)
   }
 
   private def nextVersionToFetch(ns: Namespace, device: DeviceId, currentVersion: Int): Future[Int] = {
@@ -69,7 +84,8 @@ class Roles(rolesGeneration: RolesGeneration)
     currentVersion <- deviceRepository.getCurrentVersion(device)
     assignmentVersion <- nextVersionToFetch(ns, device, currentVersion)
     latestDeviceVersion <- fileCacheRepository.fetchLatestVersion(device)
-    latestVersion <- updateCacheIfExpired(ns, device, Math.max(assignmentVersion, latestDeviceVersion.getOrElse(assignmentVersion)))
+    assignment <- deviceUpdateAssignmentRepository.find(ns, device, assignmentVersion)
+    latestVersion <- updateCacheIfExpired(ns, device, Math.max(assignmentVersion, latestDeviceVersion.getOrElse(assignmentVersion)), assignment)
   } yield latestVersion
 
   def fetchTimestamp(ns: Namespace, device: DeviceId): Future[Json] =


### PR DESCRIPTION
This forces targets.json regeneration if previous targets should have
had correlationId but did not.

This is for devices that downloaded a regenerated targets before
d3d4acbc was merged.

Additionaly, also add correlation id if device did not have a
targets.json in cache, this is due to bugfix/OTA-4539.

We are seeing some devices in prd that are pushing the following manifest:

```
{
  "attacks_detected": "",
  "ecu_serial": "<redacted>",
  "installed_image": {
    "fileinfo": {
      "hashes": {
        "sha256": "266bc0dbfc3a1fc980419ce8cd2e105b471839ffbce9e9d054d30205d3643dc8"
      },
      "length": 0
    },
    "filepath": "Release-P6<redacted>"
  },
  "previous_timeserver_time": "1970-01-01T00:00:00Z",
  "timeserver_time": "1970-01-01T00:00:00Z"
}
```

Without an installation report, while at the same time also pushing events to device registry, without a correlation id:

```
{"at":"2020-02-13T17:20:38.888Z","level":"INFO","logger":"c.a.o.deviceregistry.db.EventJournal","msg":"Could not index event (device=DeviceId(571dddb2-85d8-46b4-bd59-d04064a1dfb0),eventId=de349298-7408-458e-959d-e26fd7b562c2,eventType=EventType(EcuDownloadStarted,0)): Could not parse payload for event (device=DeviceId(571dddb2-85d8-46b4-bd59-d04064a1dfb0),eventId=de349298-7408-458e-959d-e26fd7b562c2,eventType=EventType(EcuDownloadStarted,0)): DecodingFailure(Attempt to decode value on failed cursor, List(DownField(correlationId)))"}
```

The lack of correlation id could be the cause for the missing installation report, as installation report requires a correlation id (@patrickvacek  what would the device do in this case? not produce an installation report at all?).

This change forces the regeneration of targets.json if the previously generated targets should have contained a correlation id.
